### PR TITLE
Fix mobile chord wrapping and metadata layout

### DIFF
--- a/src/chordpro-parser.js
+++ b/src/chordpro-parser.js
@@ -53,18 +53,100 @@ function extractStructuralDirective( line ) {
 	return match[ 1 ].trim();
 }
 
-function parseDirective( raw, parserState, options ) {
+function getDirectiveParts( raw ) {
 	const trimmed = raw.trim();
 	const colonPos = trimmed.indexOf( ':' );
-	let key, value;
 
 	if ( colonPos >= 0 ) {
-		key = trimmed.substring( 0, colonPos ).trim().toLowerCase();
-		value = trimmed.substring( colonPos + 1 ).trim();
-	} else {
-		key = trimmed.toLowerCase();
-		value = '';
+		return {
+			key: trimmed.substring( 0, colonPos ).trim().toLowerCase(),
+			value: trimmed.substring( colonPos + 1 ).trim(),
+		};
 	}
+
+	return {
+		key: trimmed.toLowerCase(),
+		value: '',
+	};
+}
+
+function normalizeTopMatterKey( key ) {
+	switch ( key ) {
+		case 't':
+			return 'title';
+		case 'st':
+			return 'subtitle';
+		default:
+			return key;
+	}
+}
+
+function isTopMatterDirectiveKey( key ) {
+	return [
+		'title',
+		't',
+		'subtitle',
+		'st',
+		'artist',
+		'composer',
+		'lyricist',
+		'tempo',
+		'key',
+		'capo',
+		'time',
+		'duration',
+	].includes( key );
+}
+
+function getTopMatterPriority( key ) {
+	switch ( normalizeTopMatterKey( key ) ) {
+		case 'title':
+			return 0;
+		case 'subtitle':
+			return 1;
+		case 'artist':
+			return 2;
+		case 'composer':
+			return 3;
+		case 'lyricist':
+			return 4;
+		case 'tempo':
+			return 5;
+		case 'key':
+			return 6;
+		case 'capo':
+			return 7;
+		case 'time':
+			return 8;
+		case 'duration':
+			return 9;
+		default:
+			return 100;
+	}
+}
+
+function flushTopMatter( parserState ) {
+	if ( parserState.topMatterFlushed ) {
+		return '';
+	}
+
+	parserState.topMatterFlushed = true;
+
+	if ( parserState.pendingTopMatter.length === 0 ) {
+		return '';
+	}
+
+	return parserState.pendingTopMatter
+		.sort(
+			( first, second ) =>
+				first.priority - second.priority || first.order - second.order
+		)
+		.map( ( item ) => item.html )
+		.join( '' );
+}
+
+function parseDirective( raw, parserState, options ) {
+	const { key, value } = getDirectiveParts( raw );
 
 	switch ( key ) {
 		case 'title':
@@ -94,27 +176,35 @@ function parseDirective( raw, parserState, options ) {
 				value
 			) }</div>`;
 		case 'key':
-			return `<div class="chordpro-meta chordpro-meta-key"><div class="chordpro-meta-key-row"><strong>${ escapeHtml(
+			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
 				_x( 'Key', 'musical key label', 'chordpro-block' )
-			) }:</strong> <span class="chordpro-meta-value" data-original-key="${ escapeHtml(
+			) }:</strong><span class="chordpro-meta-value" data-original-key="${ escapeHtml(
 				value
-			) }">${ escapeHtml( value ) }</span></div></div>`;
+			) }">${ escapeHtml( value ) }</span></div>`;
 		case 'capo':
-			return `<div class="chordpro-meta"><strong>${ escapeHtml(
+			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
 				_x( 'Capo', 'guitar capo position', 'chordpro-block' )
-			) }:</strong> ${ escapeHtml( value ) }</div>`;
+			) }:</strong><span class="chordpro-meta-value">${ escapeHtml(
+				value
+			) }</span></div>`;
 		case 'tempo':
-			return `<div class="chordpro-meta"><strong>${ escapeHtml(
+			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
 				__( 'Tempo', 'chordpro-block' )
-			) }:</strong> ${ escapeHtml( value ) }</div>`;
+			) }:</strong><span class="chordpro-meta-value">${ escapeHtml(
+				value
+			) }</span></div>`;
 		case 'time':
-			return `<div class="chordpro-meta"><strong>${ escapeHtml(
+			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
 				__( 'Time', 'chordpro-block' )
-			) }:</strong> ${ escapeHtml( value ) }</div>`;
+			) }:</strong><span class="chordpro-meta-value">${ escapeHtml(
+				value
+			) }</span></div>`;
 		case 'duration':
-			return `<div class="chordpro-meta"><strong>${ escapeHtml(
+			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
 				__( 'Duration', 'chordpro-block' )
-			) }:</strong> ${ escapeHtml( value ) }</div>`;
+			) }:</strong><span class="chordpro-meta-value">${ escapeHtml(
+				value
+			) }</span></div>`;
 		case 'comment':
 		case 'c':
 			return `<div class="chordpro-comment">${ escapeHtml(
@@ -255,6 +345,8 @@ export function parseChordPro( text, options = {} ) {
 	let inTab = false;
 	const parserState = {
 		openSectionCount: 0,
+		pendingTopMatter: [],
+		topMatterFlushed: false,
 	};
 
 	for ( const rawLine of lines ) {
@@ -274,6 +366,8 @@ export function parseChordPro( text, options = {} ) {
 		// Structural directives accept both ChordPro braces and a bracket-only fallback.
 		const structuralDirective = extractStructuralDirective( line );
 		if ( structuralDirective ) {
+			html += flushTopMatter( parserState );
+
 			const output = parseDirective(
 				structuralDirective,
 				parserState,
@@ -289,6 +383,30 @@ export function parseChordPro( text, options = {} ) {
 		// Directive line.
 		const directiveMatch = line.trim().match( /^\{([^}]+)\}$/ );
 		if ( directiveMatch ) {
+			const { key } = getDirectiveParts( directiveMatch[ 1 ] );
+
+			if (
+				! parserState.topMatterFlushed &&
+				isTopMatterDirectiveKey( key )
+			) {
+				const output = parseDirective(
+					directiveMatch[ 1 ],
+					parserState,
+					parserOptions
+				);
+
+				if ( output ) {
+					parserState.pendingTopMatter.push( {
+						html: output,
+						priority: getTopMatterPriority( key ),
+						order: parserState.pendingTopMatter.length,
+					} );
+				}
+				continue;
+			}
+
+			html += flushTopMatter( parserState );
+
 			const output = parseDirective(
 				directiveMatch[ 1 ],
 				parserState,
@@ -308,21 +426,26 @@ export function parseChordPro( text, options = {} ) {
 
 		// Empty line → visual spacer.
 		if ( line.trim() === '' ) {
+			html += flushTopMatter( parserState );
 			html += '<div class="chordpro-spacer"></div>';
 			continue;
 		}
 
 		// Chord line (contains at least one [...]).
 		if ( line.includes( '[' ) ) {
+			html += flushTopMatter( parserState );
 			html += parseChordLine( line );
 			continue;
 		}
 
 		// Plain lyric line.
+		html += flushTopMatter( parserState );
 		html += `<div class="chordpro-line"><p class="chordpro-lyric chordpro-lyric-plain">${ escapeHtml(
 			line
 		) }</p></div>`;
 	}
+
+	html += flushTopMatter( parserState );
 
 	while ( parserState.openSectionCount > 0 ) {
 		html += '</div>';

--- a/src/render.php
+++ b/src/render.php
@@ -220,15 +220,15 @@ $schema_json = wp_json_encode( $schema_graph, JSON_UNESCAPED_UNICODE | JSON_UNES
 $render_transpose_controls = static function () : string {
 	return '<div class="chordpro-transpose-controls" role="group" aria-label="'
 		. esc_attr__( 'Transpose chords', 'chordpro-block' )
-		. '"><div class="chordpro-meta-key-row"><strong>'
+		. '"><strong class="chordpro-meta-label">'
 		. esc_html__( 'Transpose', 'chordpro-block' )
-		. ':</strong>&nbsp;<button type="button" class="chordpro-transpose-button" data-transpose-change="-1" aria-label="'
+		. ':</strong><button type="button" class="chordpro-transpose-button" data-transpose-change="-1" aria-label="'
 		. esc_attr__( 'Lower one semitone', 'chordpro-block' )
 		. '">-</button><button type="button" class="chordpro-transpose-button" data-transpose-change="1" aria-label="'
 		. esc_attr__( 'Raise one semitone', 'chordpro-block' )
 		. '">+</button><button type="button" class="chordpro-transpose-reset" data-transpose-reset>'
 		. esc_html__( 'Reset', 'chordpro-block' )
-		. '</button></div></div>';
+		. '</button></div>';
 };
 
 /**
@@ -280,6 +280,119 @@ $extract_structural_directive = static function ( string $line ) : ?string {
 };
 
 /**
+ * Split a directive into normalized key/value parts.
+ *
+ * @param string $directive Raw directive text without outer braces.
+ * @return array{key:string,value:string}
+ */
+$get_directive_parts = static function ( string $directive ) : array {
+	$colon_pos = strpos( $directive, ':' );
+
+	if ( false !== $colon_pos ) {
+		return array(
+			'key'   => strtolower( trim( substr( $directive, 0, $colon_pos ) ) ),
+			'value' => trim( substr( $directive, $colon_pos + 1 ) ),
+		);
+	}
+
+	return array(
+		'key'   => strtolower( trim( $directive ) ),
+		'value' => '',
+	);
+};
+
+/**
+ * Map directive aliases to their canonical top-matter key.
+ *
+ * @param string $key Raw directive key.
+ * @return string
+ */
+$normalize_top_matter_key = static function ( string $key ) : string {
+	switch ( $key ) {
+		case 't':
+			return 'title';
+		case 'st':
+			return 'subtitle';
+		default:
+			return $key;
+	}
+};
+
+/**
+ * Determine whether a directive belongs to the top metadata block.
+ *
+ * @param string $key Raw directive key.
+ * @return bool
+ */
+$is_top_matter_directive_key = static function ( string $key ) : bool {
+	return in_array(
+		$key,
+		array(
+			'title',
+			't',
+			'subtitle',
+			'st',
+			'artist',
+			'composer',
+			'lyricist',
+			'tempo',
+			'key',
+			'capo',
+			'time',
+			'duration',
+		),
+		true
+	);
+};
+
+/**
+ * Determine whether a directive belongs in the compact metadata row.
+ *
+ * @param string $key Raw directive key.
+ * @return bool
+ */
+$is_meta_row_directive_key = static function ( string $key ) use ( $normalize_top_matter_key ) : bool {
+	return in_array(
+		$normalize_top_matter_key( $key ),
+		array( 'tempo', 'key', 'capo', 'time', 'duration' ),
+		true
+	);
+};
+
+/**
+ * Return the display priority for top-matter directives.
+ *
+ * @param string $key Raw directive key.
+ * @return int
+ */
+$get_top_matter_priority = static function ( string $key ) use ( $normalize_top_matter_key ) : int {
+	switch ( $normalize_top_matter_key( $key ) ) {
+		case 'title':
+			return 0;
+		case 'subtitle':
+			return 1;
+		case 'artist':
+			return 2;
+		case 'composer':
+			return 3;
+		case 'lyricist':
+			return 4;
+		case 'tempo':
+			return 5;
+		case 'key':
+			return 6;
+		case 'capo':
+			return 7;
+		case 'time':
+			return 8;
+		case 'duration':
+			return 9;
+		default:
+			return 100;
+	}
+};
+
+/**
  * Parse a raw directive string (content inside {…}) and return HTML.
  *
  * @param string $directive Raw directive, e.g. "t: Amazing Grace" or "soc".
@@ -287,17 +400,68 @@ $extract_structural_directive = static function ( string $line ) : ?string {
  */
 $controls_rendered = false;
 $open_section_count = 0;
+$pending_top_matter = array();
+$top_matter_flushed = false;
 
-$parse_directive = static function ( string $directive ) use ( $render_transpose_controls, $translate_section_label_prefix, &$controls_rendered, &$open_section_count, $show_title, $show_artist ) : string {
-	$colon_pos = strpos( $directive, ':' );
-
-	if ( false !== $colon_pos ) {
-		$key   = strtolower( trim( substr( $directive, 0, $colon_pos ) ) );
-		$value = trim( substr( $directive, $colon_pos + 1 ) );
-	} else {
-		$key   = strtolower( trim( $directive ) );
-		$value = '';
+$flush_top_matter = static function () use ( $render_transpose_controls, &$controls_rendered, &$pending_top_matter, &$top_matter_flushed ) : string {
+	if ( $top_matter_flushed ) {
+		return '';
 	}
+
+	$top_matter_flushed = true;
+
+	if ( empty( $pending_top_matter ) ) {
+		return '';
+	}
+
+	$has_meta_row_items = count(
+		array_filter(
+			$pending_top_matter,
+			static function ( array $item ) : bool {
+				return 'meta_row' === $item['group'];
+			}
+		)
+	) > 0;
+
+	usort(
+		$pending_top_matter,
+		static function ( array $first, array $second ) : int {
+			if ( $first['priority'] === $second['priority'] ) {
+				return $first['order'] <=> $second['order'];
+			}
+
+			return $first['priority'] <=> $second['priority'];
+		}
+	);
+
+	$html = '';
+	$meta_row_items = array();
+
+	foreach ( $pending_top_matter as $item ) {
+		if ( 'meta_row' === $item['group'] ) {
+			$meta_row_items[] = $item['html'];
+			continue;
+		}
+
+		$html .= $item['html'];
+	}
+
+	if ( ! empty( $meta_row_items ) ) {
+		$html .= '<div class="chordpro-meta-bar">' . implode( '', $meta_row_items ) . '</div>';
+	}
+
+	if ( $has_meta_row_items && ! $controls_rendered ) {
+		$html .= '<div class="chordpro-transpose-row">' . $render_transpose_controls() . '</div>';
+		$controls_rendered = true;
+	}
+
+	return $html;
+};
+
+$parse_directive = static function ( string $directive ) use ( $get_directive_parts, $render_transpose_controls, $translate_section_label_prefix, &$controls_rendered, &$open_section_count, $show_title, $show_artist ) : string {
+	$parts = $get_directive_parts( $directive );
+	$key   = $parts['key'];
+	$value = $parts['value'];
 
 	switch ( $key ) {
 		case 'title':
@@ -324,36 +488,29 @@ $parse_directive = static function ( string $directive ) use ( $render_transpose
 			return '<div class="chordpro-lyricist">' . esc_html( $value ) . '</div>';
 
 		case 'key':
-			$controls = '';
-
-			if ( ! $controls_rendered ) {
-				$controls          = $render_transpose_controls();
-				$controls_rendered = true;
-			}
-
-			return '<div class="chordpro-meta chordpro-meta-key"><div class="chordpro-meta-key-row"><strong>'
+			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">'
 				. esc_html_x( 'Key', 'musical key label', 'chordpro-block' )
-				. ':</strong> <span class="chordpro-meta-value" data-original-key="' . esc_attr( $value ) . '">' . esc_html( $value ) . '</span></div>' . $controls . '</div>';
+				. ':</strong><span class="chordpro-meta-value" data-original-key="' . esc_attr( $value ) . '">' . esc_html( $value ) . '</span></div>';
 
 		case 'capo':
-			return '<div class="chordpro-meta"><strong>'
+			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">'
 				. esc_html_x( 'Capo', 'guitar capo position', 'chordpro-block' )
-				. ':</strong> ' . esc_html( $value ) . '</div>';
+				. ':</strong><span class="chordpro-meta-value">' . esc_html( $value ) . '</span></div>';
 
 		case 'tempo':
-			return '<div class="chordpro-meta"><strong>'
+			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">'
 				. esc_html__( 'Tempo', 'chordpro-block' )
-				. ':</strong> ' . esc_html( $value ) . '</div>';
+				. ':</strong><span class="chordpro-meta-value">' . esc_html( $value ) . '</span></div>';
 
 		case 'time':
-			return '<div class="chordpro-meta"><strong>'
+			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">'
 				. esc_html__( 'Time', 'chordpro-block' )
-				. ':</strong> ' . esc_html( $value ) . '</div>';
+				. ':</strong><span class="chordpro-meta-value">' . esc_html( $value ) . '</span></div>';
 
 		case 'duration':
-			return '<div class="chordpro-meta"><strong>'
+			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">'
 				. esc_html__( 'Duration', 'chordpro-block' )
-				. ':</strong> ' . esc_html( $value ) . '</div>';
+				. ':</strong><span class="chordpro-meta-value">' . esc_html( $value ) . '</span></div>';
 
 		case 'comment':
 		case 'c':
@@ -484,7 +641,7 @@ $parse_chord_line = static function ( string $line ) : string {
  * @param string $text Raw ChordPro content.
  * @return string Rendered HTML.
  */
-$parse = static function ( string $text ) use ( $parse_directive, $parse_chord_line, $extract_structural_directive, &$open_section_count ) : string {
+$parse = static function ( string $text ) use ( $parse_directive, $parse_chord_line, $extract_structural_directive, $get_directive_parts, $is_top_matter_directive_key, $is_meta_row_directive_key, $get_top_matter_priority, $flush_top_matter, &$pending_top_matter, &$top_matter_flushed, &$open_section_count ) : string {
 	$lines  = explode( "\n", $text );
 	$html   = '';
 	$in_tab = false;
@@ -506,6 +663,8 @@ $parse = static function ( string $text ) use ( $parse_directive, $parse_chord_l
 		// Structural directives accept both ChordPro braces and a bracket-only fallback.
 		$structural_directive = $extract_structural_directive( $line );
 		if ( null !== $structural_directive ) {
+			$html .= $flush_top_matter();
+
 			$colon = strpos( $structural_directive, ':' );
 			$key   = strtolower( trim( false !== $colon ? substr( $structural_directive, 0, $colon ) : $structural_directive ) );
 			$output = $parse_directive( $structural_directive );
@@ -520,9 +679,24 @@ $parse = static function ( string $text ) use ( $parse_directive, $parse_chord_l
 
 		// Directive line: {key} or {key: value}.
 		if ( preg_match( '/^\{([^}]+)\}$/', trim( $line ), $m ) ) {
-			// Determine key to track tab state without depending on HTML output.
-			$colon = strpos( $m[1], ':' );
-			$key   = strtolower( trim( false !== $colon ? substr( $m[1], 0, $colon ) : $m[1] ) );
+			$parts = $get_directive_parts( $m[1] );
+			$key   = $parts['key'];
+
+			if ( ! $top_matter_flushed && $is_top_matter_directive_key( $key ) ) {
+				$output = $parse_directive( $m[1] );
+
+				if ( '' !== $output ) {
+					$pending_top_matter[] = array(
+						'html'     => $output,
+						'priority' => $get_top_matter_priority( $key ),
+						'order'    => count( $pending_top_matter ),
+						'group'    => $is_meta_row_directive_key( $key ) ? 'meta_row' : 'default',
+					);
+				}
+				continue;
+			}
+
+			$html .= $flush_top_matter();
 
 			$output = $parse_directive( $m[1] );
 
@@ -536,19 +710,24 @@ $parse = static function ( string $text ) use ( $parse_directive, $parse_chord_l
 
 		// Empty line → visual spacer.
 		if ( '' === trim( $line ) ) {
+			$html .= $flush_top_matter();
 			$html .= '<div class="chordpro-spacer"></div>';
 			continue;
 		}
 
 		// Chord line (contains at least one [...]).
 		if ( false !== strpos( $line, '[' ) ) {
+			$html .= $flush_top_matter();
 			$html .= $parse_chord_line( $line );
 			continue;
 		}
 
 		// Plain lyric line (no chords).
+		$html .= $flush_top_matter();
 		$html .= '<div class="chordpro-line"><p class="chordpro-lyric chordpro-lyric-plain">' . esc_html( $line ) . '</p></div>';
 	}
+
+	$html .= $flush_top_matter();
 
 	while ( $open_section_count > 0 ) {
 		$html .= '</div>';

--- a/src/style.scss
+++ b/src/style.scss
@@ -11,9 +11,12 @@
 .wp-block-chordpro-block-song {
 	.chordpro-transpose-controls {
 		display: flex;
-		align-items: center;
+		align-items: baseline;
 		gap: 0.5rem;
-		margin-top: 0.45rem;
+		margin-top: 0;
+		font-size: var(--wp--preset--font-size--small, 0.9rem);
+		font-family: var(--wp--preset--font-family--roboto, sans-serif);
+		font-weight: 400;
 	}
 
 	.chordpro-transpose-button,
@@ -82,20 +85,72 @@
 	}
 
 	.chordpro-meta {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.2em;
 		font-size: var(--wp--preset--font-size--small, 0.9rem);
 		font-family: var(--wp--preset--font-family--roboto, sans-serif);
-		margin: 0 0 0.1em;
+		margin: 0 1rem 0.1em 0;
+		vertical-align: top;
+	}
+
+	.chordpro-meta-bar {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.25em 1rem;
+		margin: 0 0 0.35em;
+	}
+
+	.chordpro-transpose-row {
+		margin: 0 0 0.35em;
+	}
+
+	.chordpro-meta-bar .chordpro-meta,
+	.chordpro-meta-bar .chordpro-transpose-controls {
+		margin: 0;
+	}
+
+	.chordpro-meta-label {
+		display: inline-flex;
+		align-items: center;
+		white-space: nowrap;
+	}
+
+	.chordpro-meta > strong,
+	.chordpro-transpose-controls > strong,
+	.chordpro-meta-key-row > strong {
+		margin-right: 0.2em;
 	}
 
 	.chordpro-meta-key {
+		display: inline-flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.chordpro-song > .chordpro-meta-key {
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
-		gap: 0;
+		width: 100%;
+		gap: 0.35em;
+		margin: 0 0 0.35em;
+	}
+
+	.chordpro-song > .chordpro-meta-key > .chordpro-meta-key-row:first-child {
+		margin-right: 0;
+	}
+
+	.chordpro-song > .chordpro-meta-key > .chordpro-transpose-controls {
+		display: inline-flex;
+		margin: 0;
 	}
 
 	.chordpro-meta-key-row {
-		display: flex;
+		display: inline-flex;
 		align-items: center;
 		gap: 0.25rem;
 		flex-wrap: wrap;
@@ -103,6 +158,19 @@
 
 	.chordpro-meta-value {
 		color: inherit;
+		white-space: nowrap;
+	}
+
+	.chordpro-meta-key .chordpro-meta-key-row:first-child {
+		margin-right: 0.75rem;
+	}
+
+	.chordpro-meta-key .chordpro-transpose-controls {
+		margin: 0;
+	}
+
+	.chordpro-transpose-controls .chordpro-meta-key-row {
+		align-items: baseline;
 	}
 
 	// -------------------------------------------------------------------------
@@ -214,5 +282,25 @@
 
 	.chordpro-spacer {
 		height: 0.75em;
+	}
+
+	@media (max-width: 600px) {
+		.chordpro-line-annotated {
+			padding-top: 0.65em;
+		}
+
+		.chordpro-chords {
+			height: auto;
+		}
+
+		.chordpro-chord {
+			font-size: 1em;
+		}
+
+		.chordpro-lyric-full {
+			white-space: pre-wrap;
+			overflow-wrap: anywhere;
+			line-height: 1.85;
+		}
 	}
 }

--- a/src/transpose.js
+++ b/src/transpose.js
@@ -111,21 +111,110 @@ function measureTextWidth( text, font ) {
 	return context.measureText( text ).width;
 }
 
+function getCodeUnitOffsets( text ) {
+	const offsets = [ 0 ];
+	let total = 0;
+
+	for ( const char of text ) {
+		total += char.length;
+		offsets.push( total );
+	}
+
+	return offsets;
+}
+
+function getAnchorMetrics( lyricNode, lyricChars, codeUnitOffsets, position ) {
+	const textNode = lyricNode.firstChild;
+
+	if ( ! textNode || textNode.nodeType !== 3 ) {
+		return null;
+	}
+
+	if ( lyricChars.length === 0 ) {
+		return { left: 0, top: 0 };
+	}
+
+	const safePosition = Math.max( 0, Math.min( position, lyricChars.length ) );
+	const lyricRect = lyricNode.getBoundingClientRect();
+	const range = document.createRange();
+
+	range.setStart( textNode, codeUnitOffsets[ safePosition ] );
+	range.collapse( true );
+
+	const caretRect = Array.from( range.getClientRects() ).find(
+		( currentRect ) => currentRect.width >= 0 || currentRect.height > 0
+	);
+
+	if ( caretRect ) {
+		return {
+			left: caretRect.left - lyricRect.left,
+			top: caretRect.top - lyricRect.top,
+		};
+	}
+
+	if ( safePosition < lyricChars.length ) {
+		range.setStart( textNode, codeUnitOffsets[ safePosition ] );
+		range.setEnd( textNode, codeUnitOffsets[ safePosition + 1 ] );
+
+		const rect = Array.from( range.getClientRects() ).find(
+			( currentRect ) => currentRect.width > 0 || currentRect.height > 0
+		);
+
+		if ( rect ) {
+			return {
+				left: rect.left - lyricRect.left,
+				top: rect.top - lyricRect.top,
+			};
+		}
+	}
+
+	if ( safePosition > 0 ) {
+		range.setStart( textNode, codeUnitOffsets[ safePosition - 1 ] );
+		range.setEnd( textNode, codeUnitOffsets[ safePosition ] );
+
+		const rects = Array.from( range.getClientRects() ).filter(
+			( currentRect ) => currentRect.width > 0 || currentRect.height > 0
+		);
+		const rect = rects[ rects.length - 1 ];
+
+		if ( rect ) {
+			return {
+				left: rect.right - lyricRect.left,
+				top: rect.top - lyricRect.top,
+			};
+		}
+	}
+
+	return null;
+}
+
 function recalculateLinePositions( line, offset ) {
 	const chords = Array.from(
 		line.querySelectorAll( '.chordpro-chord[data-original-chord]' )
 	);
+	const chordsContainer = line.querySelector( '.chordpro-chords' );
 	const lyricNode = line.querySelector( '.chordpro-lyric' );
 
-	if ( chords.length === 0 || ! lyricNode ) {
+	if ( chords.length === 0 || ! lyricNode || ! chordsContainer ) {
 		return;
 	}
 
 	const lyricText = lyricNode.textContent || '';
 	const lyricChars = Array.from( lyricText );
+	const codeUnitOffsets = getCodeUnitOffsets( lyricText );
 	const lyricFont = getNodeFont( lyricNode );
 	const chordFont = getNodeFont( chords[ 0 ] );
 	const chordGap = measureTextWidth( ' ', chordFont );
+	const lyricLineHeight = parseFloat(
+		window.getComputedStyle( lyricNode ).lineHeight
+	);
+	const mobileLayout = window.matchMedia( '(max-width: 600px)' ).matches;
+	const lyricHeight = lyricNode.getBoundingClientRect().height;
+	const wrappedLyric =
+		mobileLayout &&
+		Number.isFinite( lyricLineHeight ) &&
+		lyricHeight > lyricLineHeight * 1.5;
+	const positionedChords = [];
 	let previousBaseLyricPosition = null;
 	let chordOffset = 0;
 
@@ -145,10 +234,39 @@ function recalculateLinePositions( line, offset ) {
 			chordOffset = 0;
 		}
 
+		const anchorMetrics = getAnchorMetrics(
+			lyricNode,
+			lyricChars,
+			codeUnitOffsets,
+			baseLyricPosition
+		);
 		const lyricPrefix = lyricChars.slice( 0, baseLyricPosition ).join( '' );
-		const anchorLeft = measureTextWidth( lyricPrefix, lyricFont );
+		const fallbackLeft = measureTextWidth( lyricPrefix, lyricFont );
+		const anchorLeft = anchorMetrics?.left ?? fallbackLeft;
+		const visualRow =
+			mobileLayout && Number.isFinite( lyricLineHeight )
+				? Math.max(
+						0,
+						Math.round(
+							( anchorMetrics?.top ?? 0 ) / lyricLineHeight
+						)
+				  )
+				: 0;
+		let anchorTop = 0;
+
+		if (
+			mobileLayout &&
+			Number.isFinite( lyricLineHeight ) &&
+			wrappedLyric
+		) {
+			anchorTop = visualRow * lyricLineHeight + 3;
+		}
+
+		const rowKey = wrappedLyric ? visualRow : 0;
 
 		chord.style.left = `${ anchorLeft + chordOffset }px`;
+		chord.style.top = `${ anchorTop }px`;
+		positionedChords.push( { chord, rowKey } );
 
 		if ( segmentLength > 0 ) {
 			chordOffset = 0;
@@ -160,6 +278,32 @@ function recalculateLinePositions( line, offset ) {
 		if ( segmentLength === 0 ) {
 			previousBaseLyricPosition = baseLyricPosition;
 		}
+	} );
+
+	const containerRect = chordsContainer.getBoundingClientRect();
+	const previousRightByRow = new Map();
+
+	positionedChords.forEach( ( { chord, rowKey } ) => {
+		const previousRight = previousRightByRow.get( rowKey );
+		const chordRect = chord.getBoundingClientRect();
+		const chordLeft = chordRect.left - containerRect.left;
+
+		if (
+			typeof previousRight === 'number' &&
+			chordLeft < previousRight + chordGap
+		) {
+			const currentLeft = parseFloat( chord.style.left || '0' );
+			const nextLeft =
+				currentLeft + ( previousRight + chordGap - chordLeft );
+
+			chord.style.left = `${ nextLeft }px`;
+		}
+
+		const resolvedRect = chord.getBoundingClientRect();
+		previousRightByRow.set(
+			rowKey,
+			resolvedRect.right - containerRect.left
+		);
 	} );
 }
 


### PR DESCRIPTION
**Summary**
- Improve mobile chord rendering so wrapped lyric lines keep chord placement readable without horizontal scrolling or overlap
- Rework transpose collision handling to use real rendered widths and row-aware positioning
- Compact the metadata area and keep Tempo, Tonalitat, and Transposa aligned in a cleaner layout
- Apply the layout updates consistently in both frontend render and editor preview

**Testing**
- `npm run lint:js`
- `npm run build`
- Copied the built plugin into the local WordPress site for manual verification