### PR TITLE
Unify ChordPro spec across JS and PHP

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,17 @@
 	"version": "1.0.0",
 	"description": "WordPress Gutenberg block for ChordPro song notation",
 	"scripts": {
+		"generate:spec": "node scripts/generate-chordpro-spec.js",
+		"prebuild": "npm run generate:spec",
 		"build": "wp-scripts build",
+		"prestart": "npm run generate:spec",
 		"start": "wp-scripts start",
+		"prelint:js": "npm run generate:spec",
 		"lint:js": "wp-scripts lint-js",
 		"test": "npm run test:unit && npm run test:parity",
+		"pretest:parity": "npm run generate:spec",
 		"test:parity": "node scripts/test-parity.js",
+		"pretest:unit": "npm run generate:spec",
 		"test:unit": "wp-scripts test-unit-js --runInBand",
 		"packages-update": "wp-scripts packages-update"
 	},

--- a/scripts/generate-chordpro-spec.js
+++ b/scripts/generate-chordpro-spec.js
@@ -1,0 +1,68 @@
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+
+const rootDir = process.cwd();
+const specPath = path.join( rootDir, 'src', 'chordpro-spec.json' );
+const outputDir = path.join( rootDir, 'src', 'generated' );
+const phpOutputPath = path.join( outputDir, 'chordpro-spec.php' );
+const jsOutputPath = path.join( outputDir, 'chordpro-labels.js' );
+
+const specJson = fs.readFileSync( specPath, 'utf8' );
+const spec = JSON.parse( specJson );
+
+function escapeJsString( value ) {
+	return String( value ).replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
+}
+
+const phpWrapper = `<?php
+
+namespace ChordProBlock\\Parser;
+
+function get_chordpro_shared_spec() : array {
+\tstatic $spec = null;
+
+\tif ( null !== $spec ) {
+\t\treturn $spec;
+\t}
+
+\t$spec = json_decode(
+\t\t<<<'JSON'
+${ specJson }
+JSON,
+\t\ttrue
+\t);
+
+\tif ( ! is_array( $spec ) ) {
+\t\treturn array();
+\t}
+
+\treturn $spec;
+}
+`;
+
+const labelEntries = Object.entries( spec.labels )
+	.map( ( [ key, definition ] ) => {
+		const literal = `'${ escapeJsString( definition.text ) }'`;
+
+		if ( definition.function === '_x' ) {
+			return `\t\t${ key }: _x( ${ literal }, '${ escapeJsString(
+				definition.context || ''
+			) }', 'chordpro-block' ),`;
+		}
+
+		return `\t\t${ key }: __( ${ literal }, 'chordpro-block' ),`;
+	} )
+	.join( '\n' );
+
+const jsLabels = `import { __, _x } from '@wordpress/i18n';
+
+export function getGeneratedChordProLabels() {
+\treturn {
+${ labelEntries }
+\t};
+}
+`;
+
+fs.mkdirSync( outputDir, { recursive: true } );
+fs.writeFileSync( phpOutputPath, phpWrapper );
+fs.writeFileSync( jsOutputPath, jsLabels );

--- a/scripts/test-parity.js
+++ b/scripts/test-parity.js
@@ -75,23 +75,12 @@ fixtures.forEach( ( fixture, index ) => {
 		} );
 	}
 
-	fixture.expected.htmlIncludes.forEach( ( fragment ) => {
-		if ( ! phpFixture.html.includes( fragment ) ) {
-			mismatches.push( {
-				name: fixture.name,
-				reason: `Expected HTML to include "${ fragment }".`,
-			} );
-		}
-	} );
-
-	fixture.expected.htmlExcludes.forEach( ( fragment ) => {
-		if ( phpFixture.html.includes( fragment ) ) {
-			mismatches.push( {
-				name: fixture.name,
-				reason: `Expected HTML to exclude "${ fragment }".`,
-			} );
-		}
-	} );
+	if ( phpFixture.html !== fixture.expected.html ) {
+		mismatches.push( {
+			name: fixture.name,
+			reason: 'Rendered HTML does not match the shared fixture snapshot.',
+		} );
+	}
 } );
 
 if ( mismatches.length ) {

--- a/src/chordpro-document.js
+++ b/src/chordpro-document.js
@@ -1,25 +1,19 @@
-import { __, _x } from '@wordpress/i18n';
+import {
+	getChordProSpec,
+	getChordTokenRegExp,
+	getDirectiveLineRegExp,
+	getSectionLabelPrefixRegExp,
+	getStructuralDirectiveRegExp,
+} from './chordpro-spec';
 import { isTransposableChord } from './chordpro-transpose';
+import { getGeneratedChordProLabels } from './generated/chordpro-labels';
 
-const STRUCTURAL_DIRECTIVE_RE =
-	/^[{\[]\s*((?:start_of_|end_of_)(?:verse|chorus|bridge|tab)|sov|eov|soc|eoc|sob|eob|sot|eot)(?:\s*:\s*[^}\]]*)?\s*[}\]]$/i;
-const DIRECTIVE_LINE_RE = /^\{([^}]+)\}$/;
-const CHORD_TOKEN_RE = /\[[^\]]+\]/;
-
-const TOP_MATTER_KEYS = [
-	'title',
-	't',
-	'subtitle',
-	'st',
-	'artist',
-	'composer',
-	'lyricist',
-	'tempo',
-	'key',
-	'capo',
-	'time',
-	'duration',
-];
+const SPEC = getChordProSpec();
+const NODE_TYPES = SPEC.document.nodeTypes;
+const STRUCTURAL_DIRECTIVE_RE = getStructuralDirectiveRegExp( SPEC );
+const DIRECTIVE_LINE_RE = getDirectiveLineRegExp( SPEC );
+const CHORD_TOKEN_RE = getChordTokenRegExp( SPEC );
+const SECTION_LABEL_PREFIX_RE = getSectionLabelPrefixRegExp( SPEC );
 
 function escapeHtml( text ) {
 	return String( text )
@@ -28,6 +22,18 @@ function escapeHtml( text ) {
 		.replace( />/g, '&gt;' )
 		.replace( /"/g, '&quot;' )
 		.replace( /'/g, '&#039;' );
+}
+
+function getTopMatterItem( key ) {
+	return SPEC.topMatter.items[ key ] || null;
+}
+
+function getDirectiveNodeConfig( key ) {
+	return SPEC.directiveNodes[ key ] || null;
+}
+
+function getDirectiveRenderConfig( key ) {
+	return SPEC.render.directiveNodes[ key ] || null;
 }
 
 function getDirectiveParts( raw ) {
@@ -59,51 +65,19 @@ function extractStructuralDirective( line ) {
 }
 
 function normalizeTopMatterKey( key ) {
-	switch ( key ) {
-		case 't':
-			return 'title';
-		case 'st':
-			return 'subtitle';
-		default:
-			return key;
-	}
+	return getTopMatterItem( key )?.canonicalKey || key;
 }
 
 function isTopMatterDirectiveKey( key ) {
-	return TOP_MATTER_KEYS.includes( key );
+	return !! getTopMatterItem( key );
 }
 
 function isMetaRowDirectiveKey( key ) {
-	return [ 'tempo', 'key', 'capo', 'time', 'duration' ].includes(
-		normalizeTopMatterKey( key )
-	);
+	return getTopMatterItem( key )?.group === 'meta_row';
 }
 
 function getTopMatterPriority( key ) {
-	switch ( normalizeTopMatterKey( key ) ) {
-		case 'title':
-			return 0;
-		case 'subtitle':
-			return 1;
-		case 'artist':
-			return 2;
-		case 'composer':
-			return 3;
-		case 'lyricist':
-			return 4;
-		case 'tempo':
-			return 5;
-		case 'key':
-			return 6;
-		case 'capo':
-			return 7;
-		case 'time':
-			return 8;
-		case 'duration':
-			return 9;
-		default:
-			return 100;
-	}
+	return getTopMatterItem( key )?.priority ?? 100;
 }
 
 function hasChordTokens( line ) {
@@ -176,7 +150,7 @@ function parseChordLine( line ) {
 	}
 
 	return {
-		type: 'chord_line',
+		type: NODE_TYPES.chordLine,
 		lyricText,
 		accessibleText: buildAccessibleChordLine( leadingText, segments ),
 		markers,
@@ -188,34 +162,14 @@ function parseChordLine( line ) {
 
 function createEmptyDocument() {
 	return {
-		meta: {
-			title: '',
-			subtitle: '',
-			artist: '',
-			composer: '',
-			lyricist: '',
-			key: '',
-			lyrics: '',
-		},
-		features: {
-			hasChords: false,
-			hasTransposableChords: false,
-		},
+		meta: { ...SPEC.document.metaDefaults },
+		features: { ...SPEC.document.featureDefaults },
 		nodes: [],
 	};
 }
 
 function assignMetaValue( document, key, value ) {
-	const metaKey = {
-		title: 'title',
-		t: 'title',
-		subtitle: 'subtitle',
-		st: 'subtitle',
-		artist: 'artist',
-		composer: 'composer',
-		lyricist: 'lyricist',
-		key: 'key',
-	}[ key ];
+	const metaKey = getTopMatterItem( key )?.metaKey;
 
 	if ( ! metaKey || document.meta[ metaKey ] ) {
 		return;
@@ -236,101 +190,58 @@ function flushTopMatter( parserState ) {
 	}
 
 	parserState.document.nodes.push( {
-		type: 'top_matter',
+		type: NODE_TYPES.topMatter,
 		items: [ ...parserState.pendingTopMatter ],
 	} );
 }
 
 function getSectionType( key ) {
-	switch ( key ) {
-		case 'start_of_chorus':
-		case 'soc':
-			return 'chorus';
-		case 'start_of_verse':
-		case 'sov':
-			return 'verse';
-		case 'start_of_bridge':
-		case 'sob':
-			return 'bridge';
-		default:
-			return null;
-	}
+	return SPEC.structuralDirectives.sectionStarts[ key ] || null;
 }
 
 function isSectionEndKey( key ) {
-	return [
-		'end_of_chorus',
-		'eoc',
-		'end_of_verse',
-		'eov',
-		'end_of_bridge',
-		'eob',
-	].includes( key );
+	return SPEC.structuralDirectives.sectionEnds.includes( key );
+}
+
+function isTabStartKey( key ) {
+	return SPEC.structuralDirectives.tabs.starts.includes( key );
+}
+
+function isTabEndKey( key ) {
+	return SPEC.structuralDirectives.tabs.ends.includes( key );
 }
 
 function createDirectiveNode( key, value ) {
-	switch ( key ) {
-		case 'title':
-		case 't':
-		case 'subtitle':
-		case 'st':
-		case 'artist':
-		case 'composer':
-		case 'lyricist':
-		case 'tempo':
-		case 'key':
-		case 'capo':
-		case 'time':
-		case 'duration':
-			return {
-				type: 'directive',
-				key,
-				value,
-			};
-		case 'comment':
-		case 'c':
-			return {
-				type: 'comment',
-				variant: 'comment',
-				value,
-			};
-		case 'chorus':
-		case 'verse':
-		case 'bridge':
-			return {
-				type: 'comment',
-				variant: key,
-				value: '',
-			};
-		default:
-			return null;
+	const config = getDirectiveNodeConfig( key );
+
+	if ( ! config ) {
+		return null;
 	}
+
+	if ( config.type === NODE_TYPES.directive ) {
+		return {
+			type: NODE_TYPES.directive,
+			key,
+			value,
+		};
+	}
+
+	return {
+		type: NODE_TYPES.comment,
+		variant: config.variant,
+		value: config.includeValue === false ? '' : value,
+	};
 }
 
 export function getChordProLabels() {
-	return {
-		verse: __( 'Verse', 'chordpro-block' ),
-		chorus: __( 'Chorus', 'chordpro-block' ),
-		bridge: __( 'Bridge', 'chordpro-block' ),
-		keyLabel: _x( 'Key', 'musical key label', 'chordpro-block' ),
-		capoLabel: _x( 'Capo', 'guitar capo position', 'chordpro-block' ),
-		tempo: __( 'Tempo', 'chordpro-block' ),
-		time: __( 'Time', 'chordpro-block' ),
-		duration: __( 'Duration', 'chordpro-block' ),
-		transpose: __( 'Transpose', 'chordpro-block' ),
-		transposeChords: __( 'Transpose chords', 'chordpro-block' ),
-		lowerSemitone: __( 'Lower one semitone', 'chordpro-block' ),
-		raiseSemitone: __( 'Raise one semitone', 'chordpro-block' ),
-		reset: __( 'Reset', 'chordpro-block' ),
-		transposeOffset: __( 'Transpose offset 0 semitones', 'chordpro-block' ),
-	};
+	return getGeneratedChordProLabels();
 }
 
 export function translateSectionLabelPrefix(
 	value,
 	labels = getChordProLabels()
 ) {
-	const match = value.match( /^(verse|chorus|bridge)(\b.*)$/i );
+	const match = value.match( SECTION_LABEL_PREFIX_RE );
 
 	if ( ! match ) {
 		return value;
@@ -363,7 +274,7 @@ export function createChordProDocument( text ) {
 		if ( structuralDirective ) {
 			const { key, value } = getDirectiveParts( structuralDirective );
 
-			if ( [ 'start_of_tab', 'sot' ].includes( key ) ) {
+			if ( isTabStartKey( key ) ) {
 				flushTopMatter( parserState );
 
 				const tabLines = [];
@@ -381,11 +292,7 @@ export function createChordProDocument( text ) {
 						const endDirectiveParts =
 							getDirectiveParts( maybeEndDirective );
 
-						if (
-							[ 'end_of_tab', 'eot' ].includes(
-								endDirectiveParts.key
-							)
-						) {
+						if ( isTabEndKey( endDirectiveParts.key ) ) {
 							index = cursor;
 							break;
 						}
@@ -399,7 +306,7 @@ export function createChordProDocument( text ) {
 				}
 
 				document.nodes.push( {
-					type: 'tab_block',
+					type: NODE_TYPES.tabBlock,
 					lines: tabLines,
 				} );
 				continue;
@@ -411,7 +318,7 @@ export function createChordProDocument( text ) {
 				flushTopMatter( parserState );
 				parserState.sectionStack.push( sectionType );
 				document.nodes.push( {
-					type: 'section_start',
+					type: NODE_TYPES.sectionStart,
 					sectionType,
 					label: value,
 				} );
@@ -423,7 +330,7 @@ export function createChordProDocument( text ) {
 
 				if ( parserState.sectionStack.length > 0 ) {
 					document.nodes.push( {
-						type: 'section_end',
+						type: NODE_TYPES.sectionEnd,
 						sectionType: parserState.sectionStack.pop(),
 					} );
 				}
@@ -469,7 +376,7 @@ export function createChordProDocument( text ) {
 		if ( line.trim() === '' ) {
 			flushTopMatter( parserState );
 			document.nodes.push( {
-				type: 'spacer',
+				type: NODE_TYPES.spacer,
 			} );
 			lyricsLines.push( '' );
 			continue;
@@ -491,7 +398,7 @@ export function createChordProDocument( text ) {
 
 		flushTopMatter( parserState );
 		document.nodes.push( {
-			type: 'lyric_line',
+			type: NODE_TYPES.lyricLine,
 			text: line,
 		} );
 		lyricsLines.push( line );
@@ -501,7 +408,7 @@ export function createChordProDocument( text ) {
 
 	while ( parserState.sectionStack.length > 0 ) {
 		document.nodes.push( {
-			type: 'section_end',
+			type: NODE_TYPES.sectionEnd,
 			sectionType: parserState.sectionStack.pop(),
 		} );
 	}
@@ -512,84 +419,84 @@ export function createChordProDocument( text ) {
 }
 
 function renderTransposeControlsMarkup( labels ) {
+	const config = SPEC.render.transposeControls;
+	const buttons = config.buttons
+		.map( ( button ) => {
+			const attributes = [
+				'type="button"',
+				`class="${ escapeHtml( button.className ) }"`,
+			];
+
+			if ( button.kind === 'change' ) {
+				attributes.push(
+					`data-transpose-change="${ escapeHtml( button.value ) }"`
+				);
+			} else if ( button.kind === 'reset' ) {
+				attributes.push( 'data-transpose-reset' );
+			}
+
+			if ( button.disabled ) {
+				attributes.push( 'disabled' );
+			}
+
+			attributes.push(
+				`aria-label="${ escapeHtml( labels[ button.labelKey ] ) }"`
+			);
+
+			const labelText = button.textLabelKey
+				? labels[ button.textLabelKey ]
+				: button.text;
+
+			return `<button ${ attributes.join( ' ' ) }>${ escapeHtml(
+				labelText
+			) }</button>`;
+		} )
+		.join( '' );
+	const display = config.display;
+
 	return `<div class="chordpro-transpose-controls" role="group" aria-label="${ escapeHtml(
-		labels.transposeChords
+		labels[ config.groupLabelKey ]
 	) }"><strong class="chordpro-meta-label">${ escapeHtml(
-		labels.transpose
-	) }:</strong><button type="button" class="chordpro-transpose-button" data-transpose-change="-1" aria-label="${ escapeHtml(
-		labels.lowerSemitone
-	) }">-</button><button type="button" class="chordpro-transpose-button" data-transpose-change="1" aria-label="${ escapeHtml(
-		labels.raiseSemitone
-	) }">+</button><button type="button" class="chordpro-transpose-reset" data-transpose-reset disabled>${ escapeHtml(
-		labels.reset
-	) }</button><span class="chordpro-transpose-value" data-transpose-display aria-live="polite" aria-atomic="true">${ escapeHtml(
-		'0'
+		labels[ config.titleLabelKey ]
+	) }:</strong>${ buttons }<span class="${ escapeHtml(
+		display.className
+	) }" data-transpose-display aria-live="${ escapeHtml(
+		display.ariaLive
+	) }" aria-atomic="${ escapeHtml( display.ariaAtomic ) }">${ escapeHtml(
+		display.initialValue
 	) }</span></div>`;
 }
 
 function renderDirectiveNode( node, options, labels ) {
-	switch ( node.key ) {
-		case 'title':
-		case 't':
-			if ( ! options.showTitle ) {
-				return '';
-			}
-			return `<div class="chordpro-title">${ escapeHtml(
-				node.value
-			) }</div>`;
-		case 'subtitle':
-		case 'st':
-			return `<div class="chordpro-subtitle">${ escapeHtml(
-				node.value
-			) }</div>`;
-		case 'artist':
-			if ( ! options.showArtist ) {
-				return '';
-			}
-			return `<div class="chordpro-artist">${ escapeHtml(
-				node.value
-			) }</div>`;
-		case 'composer':
-			return `<div class="chordpro-composer">${ escapeHtml(
-				node.value
-			) }</div>`;
-		case 'lyricist':
-			return `<div class="chordpro-lyricist">${ escapeHtml(
-				node.value
-			) }</div>`;
-		case 'key':
-			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
-				labels.keyLabel
-			) }:</strong><span class="chordpro-meta-value" data-original-key="${ escapeHtml(
-				node.value
-			) }">${ escapeHtml( node.value ) }</span></div>`;
-		case 'capo':
-			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
-				labels.capoLabel
-			) }:</strong><span class="chordpro-meta-value">${ escapeHtml(
-				node.value
-			) }</span></div>`;
-		case 'tempo':
-			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
-				labels.tempo
-			) }:</strong><span class="chordpro-meta-value">${ escapeHtml(
-				node.value
-			) }</span></div>`;
-		case 'time':
-			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
-				labels.time
-			) }:</strong><span class="chordpro-meta-value">${ escapeHtml(
-				node.value
-			) }</span></div>`;
-		case 'duration':
-			return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
-				labels.duration
-			) }:</strong><span class="chordpro-meta-value">${ escapeHtml(
-				node.value
-			) }</span></div>`;
-		default:
-			return '';
+	const config = getDirectiveRenderConfig( node.key );
+
+	if ( ! config ) {
+		return '';
 	}
+
+	if ( config.option && ! options[ config.option ] ) {
+		return '';
+	}
+
+	if ( config.kind === 'text' ) {
+		return `<div class="${ escapeHtml( config.className ) }">${ escapeHtml(
+			node.value
+		) }</div>`;
+	}
+
+	if ( config.kind === 'meta' ) {
+		const dataAttribute = config.dataAttribute
+			? ` ${ config.dataAttribute }="${ escapeHtml( node.value ) }"`
+			: '';
+
+		return `<div class="chordpro-meta"><strong class="chordpro-meta-label">${ escapeHtml(
+			labels[ config.labelKey ]
+		) }:</strong><span class="chordpro-meta-value"${ dataAttribute }>${ escapeHtml(
+			node.value
+		) }</span></div>`;
+	}
+
+	return '';
 }
 
 function renderTopMatterNode( node, state, options, labels ) {
@@ -603,7 +510,7 @@ function renderTopMatterNode( node, state, options, labels ) {
 	items.forEach( ( item ) => {
 		const rendered = renderDirectiveNode(
 			{
-				type: 'directive',
+				type: NODE_TYPES.directive,
 				key: item.key,
 				value: item.value,
 			},
@@ -690,7 +597,7 @@ export function renderChordProDocument( document, options = {} ) {
 
 	document.nodes.forEach( ( node ) => {
 		switch ( node.type ) {
-			case 'top_matter':
+			case NODE_TYPES.topMatter:
 				html += renderTopMatterNode(
 					node,
 					state,
@@ -698,13 +605,13 @@ export function renderChordProDocument( document, options = {} ) {
 					labels
 				);
 				break;
-			case 'directive':
+			case NODE_TYPES.directive:
 				html += renderDirectiveNode( node, renderOptions, labels );
 				break;
-			case 'comment':
+			case NODE_TYPES.comment:
 				html += renderCommentNode( node, labels );
 				break;
-			case 'section_start': {
+			case NODE_TYPES.sectionStart: {
 				const sectionLabel = node.label
 					? `<div class="chordpro-section-label">${ escapeHtml(
 							translateSectionLabelPrefix( node.label, labels )
@@ -717,26 +624,26 @@ export function renderChordProDocument( document, options = {} ) {
 				state.openSections += 1;
 				break;
 			}
-			case 'section_end':
+			case NODE_TYPES.sectionEnd:
 				if ( state.openSections > 0 ) {
 					html += '</div>';
 					state.openSections -= 1;
 				}
 				break;
-			case 'tab_block':
+			case NODE_TYPES.tabBlock:
 				html += `<pre class="chordpro-tab">${ escapeHtml(
 					node.lines.join( '\n' )
 				) }</pre>`;
 				break;
-			case 'spacer':
+			case NODE_TYPES.spacer:
 				html += '<div class="chordpro-spacer"></div>';
 				break;
-			case 'lyric_line':
+			case NODE_TYPES.lyricLine:
 				html += `<div class="chordpro-line"><p class="chordpro-lyric chordpro-lyric-plain">${ escapeHtml(
 					node.text
 				) }</p></div>`;
 				break;
-			case 'chord_line':
+			case NODE_TYPES.chordLine:
 				html += renderChordLineNode( node );
 				break;
 		}

--- a/src/chordpro-spec.js
+++ b/src/chordpro-spec.js
@@ -1,0 +1,51 @@
+import rawSpec from './chordpro-spec.json';
+
+function escapeRegExp( value ) {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+}
+
+function sortLongestFirst( values ) {
+	return [ ...values ].sort(
+		( first, second ) => second.length - first.length
+	);
+}
+
+function getStructuralDirectiveKeys( spec ) {
+	return sortLongestFirst( [
+		...Object.keys( spec.structuralDirectives.sectionStarts ),
+		...spec.structuralDirectives.sectionEnds,
+		...spec.structuralDirectives.tabs.starts,
+		...spec.structuralDirectives.tabs.ends,
+	] );
+}
+
+export function getChordProSpec() {
+	return rawSpec;
+}
+
+export function getStructuralDirectiveRegExp( spec = rawSpec ) {
+	const keys = getStructuralDirectiveKeys( spec )
+		.map( escapeRegExp )
+		.join( '|' );
+
+	return new RegExp(
+		`^[{\\[]\\s*((${ keys })(?:\\s*:\\s*[^}\\]]*)?)\\s*[}\\]]$`,
+		'i'
+	);
+}
+
+export function getDirectiveLineRegExp( spec = rawSpec ) {
+	return new RegExp( spec.patterns.directiveLine );
+}
+
+export function getChordTokenRegExp( spec = rawSpec ) {
+	return new RegExp( spec.patterns.chordToken, 'u' );
+}
+
+export function getSectionLabelPrefixRegExp( spec = rawSpec ) {
+	const variants = sortLongestFirst( spec.render.sectionLabelVariants || [] )
+		.map( escapeRegExp )
+		.join( '|' );
+
+	return new RegExp( `^(${ variants })(\\b.*)$`, 'i' );
+}

--- a/src/chordpro-spec.json
+++ b/src/chordpro-spec.json
@@ -1,0 +1,353 @@
+{
+	"patterns": {
+		"directiveLine": "^\\{([^}]+)\\}$",
+		"chordToken": "\\[[^\\]]+\\]"
+	},
+	"document": {
+		"metaDefaults": {
+			"title": "",
+			"subtitle": "",
+			"artist": "",
+			"composer": "",
+			"lyricist": "",
+			"key": "",
+			"lyrics": ""
+		},
+		"featureDefaults": {
+			"hasChords": false,
+			"hasTransposableChords": false
+		},
+		"nodeTypes": {
+			"topMatter": "top_matter",
+			"directive": "directive",
+			"comment": "comment",
+			"sectionStart": "section_start",
+			"sectionEnd": "section_end",
+			"tabBlock": "tab_block",
+			"spacer": "spacer",
+			"lyricLine": "lyric_line",
+			"chordLine": "chord_line"
+		}
+	},
+	"labels": {
+		"verse": {
+			"text": "Verse",
+			"function": "__"
+		},
+		"chorus": {
+			"text": "Chorus",
+			"function": "__"
+		},
+		"bridge": {
+			"text": "Bridge",
+			"function": "__"
+		},
+		"keyLabel": {
+			"text": "Key",
+			"function": "_x",
+			"context": "musical key label"
+		},
+		"capoLabel": {
+			"text": "Capo",
+			"function": "_x",
+			"context": "guitar capo position"
+		},
+		"tempo": {
+			"text": "Tempo",
+			"function": "__"
+		},
+		"time": {
+			"text": "Time",
+			"function": "__"
+		},
+		"duration": {
+			"text": "Duration",
+			"function": "__"
+		},
+		"transpose": {
+			"text": "Transpose",
+			"function": "__"
+		},
+		"transposeChords": {
+			"text": "Transpose chords",
+			"function": "__"
+		},
+		"lowerSemitone": {
+			"text": "Lower one semitone",
+			"function": "__"
+		},
+		"raiseSemitone": {
+			"text": "Raise one semitone",
+			"function": "__"
+		},
+		"reset": {
+			"text": "Reset",
+			"function": "__"
+		},
+		"transposeOffset": {
+			"text": "Transpose offset 0 semitones",
+			"function": "__"
+		},
+		"songLyricsDefault": {
+			"text": "Song Lyrics",
+			"function": "__"
+		}
+	},
+	"topMatter": {
+		"items": {
+			"title": {
+				"canonicalKey": "title",
+				"priority": 0,
+				"group": "default",
+				"metaKey": "title"
+			},
+			"t": {
+				"canonicalKey": "title",
+				"priority": 0,
+				"group": "default",
+				"metaKey": "title"
+			},
+			"subtitle": {
+				"canonicalKey": "subtitle",
+				"priority": 1,
+				"group": "default",
+				"metaKey": "subtitle"
+			},
+			"st": {
+				"canonicalKey": "subtitle",
+				"priority": 1,
+				"group": "default",
+				"metaKey": "subtitle"
+			},
+			"artist": {
+				"canonicalKey": "artist",
+				"priority": 2,
+				"group": "default",
+				"metaKey": "artist"
+			},
+			"composer": {
+				"canonicalKey": "composer",
+				"priority": 3,
+				"group": "default",
+				"metaKey": "composer"
+			},
+			"lyricist": {
+				"canonicalKey": "lyricist",
+				"priority": 4,
+				"group": "default",
+				"metaKey": "lyricist"
+			},
+			"tempo": {
+				"canonicalKey": "tempo",
+				"priority": 5,
+				"group": "meta_row"
+			},
+			"key": {
+				"canonicalKey": "key",
+				"priority": 6,
+				"group": "meta_row",
+				"metaKey": "key"
+			},
+			"capo": {
+				"canonicalKey": "capo",
+				"priority": 7,
+				"group": "meta_row"
+			},
+			"time": {
+				"canonicalKey": "time",
+				"priority": 8,
+				"group": "meta_row"
+			},
+			"duration": {
+				"canonicalKey": "duration",
+				"priority": 9,
+				"group": "meta_row"
+			}
+		}
+	},
+	"structuralDirectives": {
+		"sectionStarts": {
+			"start_of_chorus": "chorus",
+			"soc": "chorus",
+			"start_of_verse": "verse",
+			"sov": "verse",
+			"start_of_bridge": "bridge",
+			"sob": "bridge"
+		},
+		"sectionEnds": [
+			"end_of_chorus",
+			"eoc",
+			"end_of_verse",
+			"eov",
+			"end_of_bridge",
+			"eob"
+		],
+		"tabs": {
+			"starts": [
+				"start_of_tab",
+				"sot"
+			],
+			"ends": [
+				"end_of_tab",
+				"eot"
+			]
+		}
+	},
+	"directiveNodes": {
+		"title": {
+			"type": "directive"
+		},
+		"t": {
+			"type": "directive"
+		},
+		"subtitle": {
+			"type": "directive"
+		},
+		"st": {
+			"type": "directive"
+		},
+		"artist": {
+			"type": "directive"
+		},
+		"composer": {
+			"type": "directive"
+		},
+		"lyricist": {
+			"type": "directive"
+		},
+		"tempo": {
+			"type": "directive"
+		},
+		"key": {
+			"type": "directive"
+		},
+		"capo": {
+			"type": "directive"
+		},
+		"time": {
+			"type": "directive"
+		},
+		"duration": {
+			"type": "directive"
+		},
+		"comment": {
+			"type": "comment",
+			"variant": "comment",
+			"includeValue": true
+		},
+		"c": {
+			"type": "comment",
+			"variant": "comment",
+			"includeValue": true
+		},
+		"chorus": {
+			"type": "comment",
+			"variant": "chorus",
+			"includeValue": false
+		},
+		"verse": {
+			"type": "comment",
+			"variant": "verse",
+			"includeValue": false
+		},
+		"bridge": {
+			"type": "comment",
+			"variant": "bridge",
+			"includeValue": false
+		}
+	},
+	"render": {
+		"directiveNodes": {
+			"title": {
+				"kind": "text",
+				"className": "chordpro-title",
+				"option": "showTitle"
+			},
+			"t": {
+				"kind": "text",
+				"className": "chordpro-title",
+				"option": "showTitle"
+			},
+			"subtitle": {
+				"kind": "text",
+				"className": "chordpro-subtitle"
+			},
+			"st": {
+				"kind": "text",
+				"className": "chordpro-subtitle"
+			},
+			"artist": {
+				"kind": "text",
+				"className": "chordpro-artist",
+				"option": "showArtist"
+			},
+			"composer": {
+				"kind": "text",
+				"className": "chordpro-composer"
+			},
+			"lyricist": {
+				"kind": "text",
+				"className": "chordpro-lyricist"
+			},
+			"key": {
+				"kind": "meta",
+				"labelKey": "keyLabel",
+				"dataAttribute": "data-original-key"
+			},
+			"capo": {
+				"kind": "meta",
+				"labelKey": "capoLabel"
+			},
+			"tempo": {
+				"kind": "meta",
+				"labelKey": "tempo"
+			},
+			"time": {
+				"kind": "meta",
+				"labelKey": "time"
+			},
+			"duration": {
+				"kind": "meta",
+				"labelKey": "duration"
+			}
+		},
+		"sectionLabelVariants": [
+			"verse",
+			"chorus",
+			"bridge"
+		],
+		"transposeControls": {
+			"groupLabelKey": "transposeChords",
+			"titleLabelKey": "transpose",
+			"buttons": [
+				{
+					"kind": "change",
+					"value": "-1",
+					"className": "chordpro-transpose-button",
+					"labelKey": "lowerSemitone",
+					"text": "-"
+				},
+				{
+					"kind": "change",
+					"value": "1",
+					"className": "chordpro-transpose-button",
+					"labelKey": "raiseSemitone",
+					"text": "+"
+				},
+				{
+					"kind": "reset",
+					"className": "chordpro-transpose-reset",
+					"labelKey": "reset",
+					"textLabelKey": "reset",
+					"disabled": true
+				}
+			],
+			"display": {
+				"className": "chordpro-transpose-value",
+				"initialValue": "0",
+				"ariaLive": "polite",
+				"ariaAtomic": "true"
+			}
+		}
+	}
+}

--- a/src/generated/chordpro-labels.js
+++ b/src/generated/chordpro-labels.js
@@ -1,0 +1,21 @@
+import { __, _x } from '@wordpress/i18n';
+
+export function getGeneratedChordProLabels() {
+	return {
+		verse: __( 'Verse', 'chordpro-block' ),
+		chorus: __( 'Chorus', 'chordpro-block' ),
+		bridge: __( 'Bridge', 'chordpro-block' ),
+		keyLabel: _x( 'Key', 'musical key label', 'chordpro-block' ),
+		capoLabel: _x( 'Capo', 'guitar capo position', 'chordpro-block' ),
+		tempo: __( 'Tempo', 'chordpro-block' ),
+		time: __( 'Time', 'chordpro-block' ),
+		duration: __( 'Duration', 'chordpro-block' ),
+		transpose: __( 'Transpose', 'chordpro-block' ),
+		transposeChords: __( 'Transpose chords', 'chordpro-block' ),
+		lowerSemitone: __( 'Lower one semitone', 'chordpro-block' ),
+		raiseSemitone: __( 'Raise one semitone', 'chordpro-block' ),
+		reset: __( 'Reset', 'chordpro-block' ),
+		transposeOffset: __( 'Transpose offset 0 semitones', 'chordpro-block' ),
+		songLyricsDefault: __( 'Song Lyrics', 'chordpro-block' ),
+	};
+}

--- a/src/generated/chordpro-spec.php
+++ b/src/generated/chordpro-spec.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace ChordProBlock\Parser;
+
+function get_chordpro_shared_spec() : array {
+	static $spec = null;
+
+	if ( null !== $spec ) {
+		return $spec;
+	}
+
+	$spec = json_decode(
+		<<<'JSON'
+{
+	"patterns": {
+		"directiveLine": "^\\{([^}]+)\\}$",
+		"chordToken": "\\[[^\\]]+\\]"
+	},
+	"document": {
+		"metaDefaults": {
+			"title": "",
+			"subtitle": "",
+			"artist": "",
+			"composer": "",
+			"lyricist": "",
+			"key": "",
+			"lyrics": ""
+		},
+		"featureDefaults": {
+			"hasChords": false,
+			"hasTransposableChords": false
+		},
+		"nodeTypes": {
+			"topMatter": "top_matter",
+			"directive": "directive",
+			"comment": "comment",
+			"sectionStart": "section_start",
+			"sectionEnd": "section_end",
+			"tabBlock": "tab_block",
+			"spacer": "spacer",
+			"lyricLine": "lyric_line",
+			"chordLine": "chord_line"
+		}
+	},
+	"labels": {
+		"verse": {
+			"text": "Verse",
+			"function": "__"
+		},
+		"chorus": {
+			"text": "Chorus",
+			"function": "__"
+		},
+		"bridge": {
+			"text": "Bridge",
+			"function": "__"
+		},
+		"keyLabel": {
+			"text": "Key",
+			"function": "_x",
+			"context": "musical key label"
+		},
+		"capoLabel": {
+			"text": "Capo",
+			"function": "_x",
+			"context": "guitar capo position"
+		},
+		"tempo": {
+			"text": "Tempo",
+			"function": "__"
+		},
+		"time": {
+			"text": "Time",
+			"function": "__"
+		},
+		"duration": {
+			"text": "Duration",
+			"function": "__"
+		},
+		"transpose": {
+			"text": "Transpose",
+			"function": "__"
+		},
+		"transposeChords": {
+			"text": "Transpose chords",
+			"function": "__"
+		},
+		"lowerSemitone": {
+			"text": "Lower one semitone",
+			"function": "__"
+		},
+		"raiseSemitone": {
+			"text": "Raise one semitone",
+			"function": "__"
+		},
+		"reset": {
+			"text": "Reset",
+			"function": "__"
+		},
+		"transposeOffset": {
+			"text": "Transpose offset 0 semitones",
+			"function": "__"
+		},
+		"songLyricsDefault": {
+			"text": "Song Lyrics",
+			"function": "__"
+		}
+	},
+	"topMatter": {
+		"items": {
+			"title": {
+				"canonicalKey": "title",
+				"priority": 0,
+				"group": "default",
+				"metaKey": "title"
+			},
+			"t": {
+				"canonicalKey": "title",
+				"priority": 0,
+				"group": "default",
+				"metaKey": "title"
+			},
+			"subtitle": {
+				"canonicalKey": "subtitle",
+				"priority": 1,
+				"group": "default",
+				"metaKey": "subtitle"
+			},
+			"st": {
+				"canonicalKey": "subtitle",
+				"priority": 1,
+				"group": "default",
+				"metaKey": "subtitle"
+			},
+			"artist": {
+				"canonicalKey": "artist",
+				"priority": 2,
+				"group": "default",
+				"metaKey": "artist"
+			},
+			"composer": {
+				"canonicalKey": "composer",
+				"priority": 3,
+				"group": "default",
+				"metaKey": "composer"
+			},
+			"lyricist": {
+				"canonicalKey": "lyricist",
+				"priority": 4,
+				"group": "default",
+				"metaKey": "lyricist"
+			},
+			"tempo": {
+				"canonicalKey": "tempo",
+				"priority": 5,
+				"group": "meta_row"
+			},
+			"key": {
+				"canonicalKey": "key",
+				"priority": 6,
+				"group": "meta_row",
+				"metaKey": "key"
+			},
+			"capo": {
+				"canonicalKey": "capo",
+				"priority": 7,
+				"group": "meta_row"
+			},
+			"time": {
+				"canonicalKey": "time",
+				"priority": 8,
+				"group": "meta_row"
+			},
+			"duration": {
+				"canonicalKey": "duration",
+				"priority": 9,
+				"group": "meta_row"
+			}
+		}
+	},
+	"structuralDirectives": {
+		"sectionStarts": {
+			"start_of_chorus": "chorus",
+			"soc": "chorus",
+			"start_of_verse": "verse",
+			"sov": "verse",
+			"start_of_bridge": "bridge",
+			"sob": "bridge"
+		},
+		"sectionEnds": [
+			"end_of_chorus",
+			"eoc",
+			"end_of_verse",
+			"eov",
+			"end_of_bridge",
+			"eob"
+		],
+		"tabs": {
+			"starts": [
+				"start_of_tab",
+				"sot"
+			],
+			"ends": [
+				"end_of_tab",
+				"eot"
+			]
+		}
+	},
+	"directiveNodes": {
+		"title": {
+			"type": "directive"
+		},
+		"t": {
+			"type": "directive"
+		},
+		"subtitle": {
+			"type": "directive"
+		},
+		"st": {
+			"type": "directive"
+		},
+		"artist": {
+			"type": "directive"
+		},
+		"composer": {
+			"type": "directive"
+		},
+		"lyricist": {
+			"type": "directive"
+		},
+		"tempo": {
+			"type": "directive"
+		},
+		"key": {
+			"type": "directive"
+		},
+		"capo": {
+			"type": "directive"
+		},
+		"time": {
+			"type": "directive"
+		},
+		"duration": {
+			"type": "directive"
+		},
+		"comment": {
+			"type": "comment",
+			"variant": "comment",
+			"includeValue": true
+		},
+		"c": {
+			"type": "comment",
+			"variant": "comment",
+			"includeValue": true
+		},
+		"chorus": {
+			"type": "comment",
+			"variant": "chorus",
+			"includeValue": false
+		},
+		"verse": {
+			"type": "comment",
+			"variant": "verse",
+			"includeValue": false
+		},
+		"bridge": {
+			"type": "comment",
+			"variant": "bridge",
+			"includeValue": false
+		}
+	},
+	"render": {
+		"directiveNodes": {
+			"title": {
+				"kind": "text",
+				"className": "chordpro-title",
+				"option": "showTitle"
+			},
+			"t": {
+				"kind": "text",
+				"className": "chordpro-title",
+				"option": "showTitle"
+			},
+			"subtitle": {
+				"kind": "text",
+				"className": "chordpro-subtitle"
+			},
+			"st": {
+				"kind": "text",
+				"className": "chordpro-subtitle"
+			},
+			"artist": {
+				"kind": "text",
+				"className": "chordpro-artist",
+				"option": "showArtist"
+			},
+			"composer": {
+				"kind": "text",
+				"className": "chordpro-composer"
+			},
+			"lyricist": {
+				"kind": "text",
+				"className": "chordpro-lyricist"
+			},
+			"key": {
+				"kind": "meta",
+				"labelKey": "keyLabel",
+				"dataAttribute": "data-original-key"
+			},
+			"capo": {
+				"kind": "meta",
+				"labelKey": "capoLabel"
+			},
+			"tempo": {
+				"kind": "meta",
+				"labelKey": "tempo"
+			},
+			"time": {
+				"kind": "meta",
+				"labelKey": "time"
+			},
+			"duration": {
+				"kind": "meta",
+				"labelKey": "duration"
+			}
+		},
+		"sectionLabelVariants": [
+			"verse",
+			"chorus",
+			"bridge"
+		],
+		"transposeControls": {
+			"groupLabelKey": "transposeChords",
+			"titleLabelKey": "transpose",
+			"buttons": [
+				{
+					"kind": "change",
+					"value": "-1",
+					"className": "chordpro-transpose-button",
+					"labelKey": "lowerSemitone",
+					"text": "-"
+				},
+				{
+					"kind": "change",
+					"value": "1",
+					"className": "chordpro-transpose-button",
+					"labelKey": "raiseSemitone",
+					"text": "+"
+				},
+				{
+					"kind": "reset",
+					"className": "chordpro-transpose-reset",
+					"labelKey": "reset",
+					"textLabelKey": "reset",
+					"disabled": true
+				}
+			],
+			"display": {
+				"className": "chordpro-transpose-value",
+				"initialValue": "0",
+				"ariaLive": "polite",
+				"ariaAtomic": "true"
+			}
+		}
+	}
+}
+
+JSON,
+		true
+	);
+
+	if ( ! is_array( $spec ) ) {
+		return array();
+	}
+
+	return $spec;
+}

--- a/src/parser.php
+++ b/src/parser.php
@@ -8,24 +8,153 @@
 
 namespace ChordProBlock\Parser;
 
-function default_labels() : array {
-	return array(
-		'verse'             => 'Verse',
-		'chorus'            => 'Chorus',
-		'bridge'            => 'Bridge',
-		'keyLabel'          => 'Key',
-		'capoLabel'         => 'Capo',
-		'tempo'             => 'Tempo',
-		'time'              => 'Time',
-		'duration'          => 'Duration',
-		'transpose'         => 'Transpose',
-		'transposeChords'   => 'Transpose chords',
-		'lowerSemitone'     => 'Lower one semitone',
-		'raiseSemitone'     => 'Raise one semitone',
-		'reset'             => 'Reset',
-		'transposeOffset'   => 'Transpose offset 0 semitones',
-		'songLyricsDefault' => 'Song Lyrics',
+require_once __DIR__ . '/generated/chordpro-spec.php';
+
+function get_spec() : array {
+	return get_chordpro_shared_spec();
+}
+
+function get_label_definitions() : array {
+	return get_spec()['labels'] ?? array();
+}
+
+function get_node_types() : array {
+	return get_spec()['document']['nodeTypes'] ?? array();
+}
+
+function get_top_matter_item( string $key ) : ?array {
+	$items = get_spec()['topMatter']['items'] ?? array();
+
+	return $items[ $key ] ?? null;
+}
+
+function get_directive_node_config( string $key ) : ?array {
+	$config = get_spec()['directiveNodes'] ?? array();
+
+	return $config[ $key ] ?? null;
+}
+
+function get_directive_render_config( string $key ) : ?array {
+	$config = get_spec()['render']['directiveNodes'] ?? array();
+
+	return $config[ $key ] ?? null;
+}
+
+function compile_preg_pattern( string $source, string $flags = '' ) : string {
+	return '/' . str_replace( '/', '\/', $source ) . '/' . $flags;
+}
+
+function get_structural_directive_pattern() : string {
+	static $pattern = null;
+
+	if ( null !== $pattern ) {
+		return $pattern;
+	}
+
+	$spec         = get_spec();
+	$structural   = $spec['structuralDirectives'] ?? array();
+	$section_keys = array_keys( $structural['sectionStarts'] ?? array() );
+	$section_ends = $structural['sectionEnds'] ?? array();
+	$tab_starts   = $structural['tabs']['starts'] ?? array();
+	$tab_ends     = $structural['tabs']['ends'] ?? array();
+	$keys         = array_values(
+		array_unique(
+			array_merge(
+				$section_keys,
+				$section_ends,
+				$tab_starts,
+				$tab_ends
+			)
+		)
 	);
+
+	usort(
+		$keys,
+		static function ( string $first, string $second ) : int {
+			return strlen( $second ) <=> strlen( $first );
+		}
+	);
+
+	$pattern = '/^[{\[]\s*((' . implode(
+		'|',
+		array_map(
+			static function ( string $value ) : string {
+				return preg_quote( $value, '/' );
+			},
+			$keys
+		)
+	) . ')(?:\s*:\s*[^}\]]*)?)\s*[}\]]$/i';
+
+	return $pattern;
+}
+
+function get_directive_line_pattern() : string {
+	static $pattern = null;
+
+	if ( null !== $pattern ) {
+		return $pattern;
+	}
+
+	$pattern = compile_preg_pattern(
+		get_spec()['patterns']['directiveLine'] ?? '^\\{([^}]+)\\}$',
+		'u'
+	);
+
+	return $pattern;
+}
+
+function get_chord_token_pattern() : string {
+	static $pattern = null;
+
+	if ( null !== $pattern ) {
+		return $pattern;
+	}
+
+	$pattern = compile_preg_pattern(
+		get_spec()['patterns']['chordToken'] ?? '\\[[^\\]]+\\]',
+		'u'
+	);
+
+	return $pattern;
+}
+
+function get_section_label_prefix_pattern() : string {
+	static $pattern = null;
+
+	if ( null !== $pattern ) {
+		return $pattern;
+	}
+
+	$variants = get_spec()['render']['sectionLabelVariants'] ?? array();
+
+	usort(
+		$variants,
+		static function ( string $first, string $second ) : int {
+			return strlen( $second ) <=> strlen( $first );
+		}
+	);
+
+	$pattern = '/^(' . implode(
+		'|',
+		array_map(
+			static function ( string $value ) : string {
+				return preg_quote( $value, '/' );
+			},
+			$variants
+		)
+	) . ')(\b.*)$/i';
+
+	return $pattern;
+}
+
+function default_labels() : array {
+	$labels = array();
+
+	foreach ( get_label_definitions() as $key => $definition ) {
+		$labels[ $key ] = $definition['text'];
+	}
+
+	return $labels;
 }
 
 function get_labels( array $overrides = array() ) : array {
@@ -44,30 +173,6 @@ function string_length( string $value ) : int {
 	preg_match_all( '/./us', $value, $matches );
 
 	return count( $matches[0] );
-}
-
-function string_substr( string $value, int $start, ?int $length = null ) : string {
-	if ( function_exists( 'mb_substr' ) ) {
-		return null === $length ? mb_substr( $value, $start ) : mb_substr( $value, $start, $length );
-	}
-
-	$chars = preg_split( '//u', $value, -1, PREG_SPLIT_NO_EMPTY );
-
-	if ( false === $chars ) {
-		return '';
-	}
-
-	$slice = null === $length ? array_slice( $chars, $start ) : array_slice( $chars, $start, $length );
-
-	return implode( '', $slice );
-}
-
-function string_pos( string $value, string $needle ) {
-	if ( function_exists( 'mb_strpos' ) ) {
-		return mb_strpos( $value, $needle );
-	}
-
-	return strpos( $value, $needle );
 }
 
 function get_directive_parts( string $raw ) : array {
@@ -90,7 +195,7 @@ function get_directive_parts( string $raw ) : array {
 function extract_structural_directive( string $line ) : ?string {
 	$trimmed = trim( $line );
 
-	if ( ! preg_match( '/^[{\[]\s*((?:start_of_|end_of_)(?:verse|chorus|bridge|tab)|sov|eov|soc|eoc|sob|eob|sot|eot)(?:\s*:\s*[^}\]]*)?\s*[}\]]$/i', $trimmed, $matches ) ) {
+	if ( ! preg_match( get_structural_directive_pattern(), $trimmed, $matches ) ) {
 		return null;
 	}
 
@@ -98,74 +203,23 @@ function extract_structural_directive( string $line ) : ?string {
 }
 
 function normalize_top_matter_key( string $key ) : string {
-	switch ( $key ) {
-		case 't':
-			return 'title';
-		case 'st':
-			return 'subtitle';
-		default:
-			return $key;
-	}
+	return get_top_matter_item( $key )['canonicalKey'] ?? $key;
 }
 
 function is_top_matter_directive_key( string $key ) : bool {
-	return in_array(
-		$key,
-		array(
-			'title',
-			't',
-			'subtitle',
-			'st',
-			'artist',
-			'composer',
-			'lyricist',
-			'tempo',
-			'key',
-			'capo',
-			'time',
-			'duration',
-		),
-		true
-	);
+	return null !== get_top_matter_item( $key );
 }
 
 function is_meta_row_directive_key( string $key ) : bool {
-	return in_array(
-		normalize_top_matter_key( $key ),
-		array( 'tempo', 'key', 'capo', 'time', 'duration' ),
-		true
-	);
+	return 'meta_row' === ( get_top_matter_item( $key )['group'] ?? null );
 }
 
 function get_top_matter_priority( string $key ) : int {
-	switch ( normalize_top_matter_key( $key ) ) {
-		case 'title':
-			return 0;
-		case 'subtitle':
-			return 1;
-		case 'artist':
-			return 2;
-		case 'composer':
-			return 3;
-		case 'lyricist':
-			return 4;
-		case 'tempo':
-			return 5;
-		case 'key':
-			return 6;
-		case 'capo':
-			return 7;
-		case 'time':
-			return 8;
-		case 'duration':
-			return 9;
-		default:
-			return 100;
-	}
+	return get_top_matter_item( $key )['priority'] ?? 100;
 }
 
 function has_chord_tokens( string $line ) : bool {
-	return 1 === preg_match( '/\[[^\]]+\]/u', $line );
+	return 1 === preg_match( get_chord_token_pattern(), $line );
 }
 
 function normalize_whitespace( string $value ) : string {
@@ -173,7 +227,7 @@ function normalize_whitespace( string $value ) : string {
 }
 
 function build_accessible_chord_line( string $leading_text, array $segments ) : string {
-	$parts = array();
+	$parts                   = array();
 	$normalized_leading_text = normalize_whitespace( $leading_text );
 
 	if ( '' !== $normalized_leading_text ) {
@@ -198,13 +252,14 @@ function is_transposable_chord( string $chord ) : bool {
 }
 
 function parse_chord_line( string $line ) : array {
-	$lyric_text    = '';
-	$markers       = array();
-	$segments      = array();
-	$first_bracket = strpos( $line, '[' );
-	$lyric_position = 0;
-	$chord_offset   = 0;
-	$leading_text   = '';
+	$node_types      = get_node_types();
+	$lyric_text      = '';
+	$markers         = array();
+	$segments        = array();
+	$first_bracket   = strpos( $line, '[' );
+	$lyric_position  = 0;
+	$chord_offset    = 0;
+	$leading_text    = '';
 
 	if ( false !== $first_bracket && $first_bracket > 0 ) {
 		$leading_text    = substr( $line, 0, $first_bracket );
@@ -215,12 +270,12 @@ function parse_chord_line( string $line ) : array {
 	preg_match_all( '/\[([^\]]*)\]([^\[]*)/u', $line, $matches, PREG_SET_ORDER );
 
 	foreach ( $matches as $match ) {
-		$chord            = $match[1];
-		$lyric            = $match[2];
-		$segment_length   = string_length( $lyric );
-		$chord_length     = string_length( $chord );
-		$base_position    = $lyric_position;
-		$chord_position   = $lyric_position + $chord_offset;
+		$chord          = $match[1];
+		$lyric          = $match[2];
+		$segment_length = string_length( $lyric );
+		$chord_length   = string_length( $chord );
+		$base_position  = $lyric_position;
+		$chord_position = $lyric_position + $chord_offset;
 
 		$markers[] = array(
 			'chord'              => $chord,
@@ -252,52 +307,28 @@ function parse_chord_line( string $line ) : array {
 	}
 
 	return array(
-		'type'                => 'chord_line',
-		'lyricText'           => $lyric_text,
-		'accessibleText'      => build_accessible_chord_line( $leading_text, $segments ),
-		'markers'             => $markers,
+		'type'                 => $node_types['chordLine'],
+		'lyricText'            => $lyric_text,
+		'accessibleText'       => build_accessible_chord_line( $leading_text, $segments ),
+		'markers'              => $markers,
 		'hasTransposableChord' => $has_transposable,
 	);
 }
 
 function create_empty_document() : array {
+	$spec = get_spec();
+
 	return array(
-		'meta'     => array(
-			'title'     => '',
-			'subtitle'  => '',
-			'artist'    => '',
-			'composer'  => '',
-			'lyricist'  => '',
-			'key'       => '',
-			'lyrics'    => '',
-		),
-		'features' => array(
-			'hasChords'             => false,
-			'hasTransposableChords' => false,
-		),
+		'meta'     => $spec['document']['metaDefaults'] ?? array(),
+		'features' => $spec['document']['featureDefaults'] ?? array(),
 		'nodes'    => array(),
 	);
 }
 
 function assign_meta_value( array &$document, string $key, string $value ) : void {
-	$meta_key_map = array(
-		'title'    => 'title',
-		't'        => 'title',
-		'subtitle' => 'subtitle',
-		'st'       => 'subtitle',
-		'artist'   => 'artist',
-		'composer' => 'composer',
-		'lyricist' => 'lyricist',
-		'key'      => 'key',
-	);
+	$meta_key = get_top_matter_item( $key )['metaKey'] ?? null;
 
-	if ( ! isset( $meta_key_map[ $key ] ) ) {
-		return;
-	}
-
-	$meta_key = $meta_key_map[ $key ];
-
-	if ( '' !== $document['meta'][ $meta_key ] ) {
+	if ( null === $meta_key || '' !== $document['meta'][ $meta_key ] ) {
 		return;
 	}
 
@@ -305,6 +336,8 @@ function assign_meta_value( array &$document, string $key, string $value ) : voi
 }
 
 function flush_top_matter( array &$document, array &$pending_top_matter, bool &$top_matter_flushed ) : void {
+	$node_types = get_node_types();
+
 	if ( $top_matter_flushed ) {
 		return;
 	}
@@ -316,75 +349,52 @@ function flush_top_matter( array &$document, array &$pending_top_matter, bool &$
 	}
 
 	$document['nodes'][] = array(
-		'type'  => 'top_matter',
+		'type'  => $node_types['topMatter'],
 		'items' => array_values( $pending_top_matter ),
 	);
 }
 
 function get_section_type( string $key ) : ?string {
-	switch ( $key ) {
-		case 'start_of_chorus':
-		case 'soc':
-			return 'chorus';
-		case 'start_of_verse':
-		case 'sov':
-			return 'verse';
-		case 'start_of_bridge':
-		case 'sob':
-			return 'bridge';
-		default:
-			return null;
-	}
+	return get_spec()['structuralDirectives']['sectionStarts'][ $key ] ?? null;
 }
 
 function is_section_end_key( string $key ) : bool {
-	return in_array(
-		$key,
-		array( 'end_of_chorus', 'eoc', 'end_of_verse', 'eov', 'end_of_bridge', 'eob' ),
-		true
-	);
+	return in_array( $key, get_spec()['structuralDirectives']['sectionEnds'] ?? array(), true );
+}
+
+function is_tab_start_key( string $key ) : bool {
+	return in_array( $key, get_spec()['structuralDirectives']['tabs']['starts'] ?? array(), true );
+}
+
+function is_tab_end_key( string $key ) : bool {
+	return in_array( $key, get_spec()['structuralDirectives']['tabs']['ends'] ?? array(), true );
 }
 
 function create_directive_node( string $key, string $value ) : ?array {
-	switch ( $key ) {
-		case 'title':
-		case 't':
-		case 'subtitle':
-		case 'st':
-		case 'artist':
-		case 'composer':
-		case 'lyricist':
-		case 'tempo':
-		case 'key':
-		case 'capo':
-		case 'time':
-		case 'duration':
-			return array(
-				'type'  => 'directive',
-				'key'   => $key,
-				'value' => $value,
-			);
-		case 'comment':
-		case 'c':
-			return array(
-				'type'    => 'comment',
-				'variant' => 'comment',
-				'value'   => $value,
-			);
-		case 'chorus':
-		case 'verse':
-		case 'bridge':
-			return array(
-				'type'    => 'comment',
-				'variant' => $key,
-				'value'   => '',
-			);
-		default:
-			return null;
+	$node_types = get_node_types();
+	$config     = get_directive_node_config( $key );
+
+	if ( null === $config ) {
+		return null;
 	}
+
+	if ( $node_types['directive'] === $config['type'] ) {
+		return array(
+			'type'  => $node_types['directive'],
+			'key'   => $key,
+			'value' => $value,
+		);
+	}
+
+	return array(
+		'type'    => $node_types['comment'],
+		'variant' => $config['variant'],
+		'value'   => false === ( $config['includeValue'] ?? true ) ? '' : $value,
+	);
 }
 
 function parse_chordpro_document( string $text ) : array {
+	$node_types         = get_node_types();
 	$lines              = explode( "\n", $text );
 	$document           = create_empty_document();
 	$lyrics_lines       = array();
@@ -393,7 +403,7 @@ function parse_chordpro_document( string $text ) : array {
 	$section_stack      = array();
 
 	for ( $index = 0, $count = count( $lines ); $index < $count; $index++ ) {
-		$line = rtrim( $lines[ $index ] );
+		$line                 = rtrim( $lines[ $index ] );
 		$structural_directive = extract_structural_directive( $line );
 
 		if ( null !== $structural_directive ) {
@@ -401,18 +411,18 @@ function parse_chordpro_document( string $text ) : array {
 			$key             = $directive_parts['key'];
 			$value           = $directive_parts['value'];
 
-			if ( in_array( $key, array( 'start_of_tab', 'sot' ), true ) ) {
+			if ( is_tab_start_key( $key ) ) {
 				flush_top_matter( $document, $pending_top_matter, $top_matter_flushed );
 				$tab_lines = array();
 
 				for ( $cursor = $index + 1; $cursor < $count; $cursor++ ) {
-					$tab_line = rtrim( $lines[ $cursor ] );
-					$end_directive = extract_structural_directive( $tab_line );
+					$tab_line       = rtrim( $lines[ $cursor ] );
+					$end_directive  = extract_structural_directive( $tab_line );
 
 					if ( null !== $end_directive ) {
 						$end_parts = get_directive_parts( $end_directive );
 
-						if ( in_array( $end_parts['key'], array( 'end_of_tab', 'eot' ), true ) ) {
+						if ( is_tab_end_key( $end_parts['key'] ) ) {
 							$index = $cursor;
 							break;
 						}
@@ -426,7 +436,7 @@ function parse_chordpro_document( string $text ) : array {
 				}
 
 				$document['nodes'][] = array(
-					'type'  => 'tab_block',
+					'type'  => $node_types['tabBlock'],
 					'lines' => $tab_lines,
 				);
 				continue;
@@ -438,7 +448,7 @@ function parse_chordpro_document( string $text ) : array {
 				flush_top_matter( $document, $pending_top_matter, $top_matter_flushed );
 				$section_stack[] = $section_type;
 				$document['nodes'][] = array(
-					'type'        => 'section_start',
+					'type'        => $node_types['sectionStart'],
 					'sectionType' => $section_type,
 					'label'       => $value,
 				);
@@ -450,7 +460,7 @@ function parse_chordpro_document( string $text ) : array {
 
 				if ( ! empty( $section_stack ) ) {
 					$document['nodes'][] = array(
-						'type'        => 'section_end',
+						'type'        => $node_types['sectionEnd'],
 						'sectionType' => array_pop( $section_stack ),
 					);
 				}
@@ -458,7 +468,7 @@ function parse_chordpro_document( string $text ) : array {
 			}
 		}
 
-		if ( preg_match( '/^\{([^}]+)\}$/', trim( $line ), $directive_match ) ) {
+		if ( preg_match( get_directive_line_pattern(), trim( $line ), $directive_match ) ) {
 			$directive_parts = get_directive_parts( $directive_match[1] );
 			$key             = $directive_parts['key'];
 			$value           = $directive_parts['value'];
@@ -489,7 +499,7 @@ function parse_chordpro_document( string $text ) : array {
 		if ( '' === trim( $line ) ) {
 			flush_top_matter( $document, $pending_top_matter, $top_matter_flushed );
 			$document['nodes'][] = array(
-				'type' => 'spacer',
+				'type' => $node_types['spacer'],
 			);
 			$lyrics_lines[] = '';
 			continue;
@@ -499,16 +509,16 @@ function parse_chordpro_document( string $text ) : array {
 			flush_top_matter( $document, $pending_top_matter, $top_matter_flushed );
 			$chord_line = parse_chord_line( $line );
 
-			$document['features']['hasChords'] = true;
+			$document['features']['hasChords']             = true;
 			$document['features']['hasTransposableChords'] = $document['features']['hasTransposableChords'] || $chord_line['hasTransposableChord'];
-			$document['nodes'][] = $chord_line;
-			$lyrics_lines[] = $chord_line['lyricText'];
+			$document['nodes'][]                           = $chord_line;
+			$lyrics_lines[]                                = $chord_line['lyricText'];
 			continue;
 		}
 
 		flush_top_matter( $document, $pending_top_matter, $top_matter_flushed );
 		$document['nodes'][] = array(
-			'type' => 'lyric_line',
+			'type' => $node_types['lyricLine'],
 			'text' => $line,
 		);
 		$lyrics_lines[] = $line;
@@ -518,7 +528,7 @@ function parse_chordpro_document( string $text ) : array {
 
 	while ( ! empty( $section_stack ) ) {
 		$document['nodes'][] = array(
-			'type'        => 'section_end',
+			'type'        => $node_types['sectionEnd'],
 			'sectionType' => array_pop( $section_stack ),
 		);
 	}
@@ -529,7 +539,7 @@ function parse_chordpro_document( string $text ) : array {
 }
 
 function translate_section_label_prefix( string $value, array $labels ) : string {
-	if ( ! preg_match( '/^(verse|chorus|bridge)(\b.*)$/i', $value, $matches ) ) {
+	if ( ! preg_match( get_section_label_prefix_pattern(), $value, $matches ) ) {
 		return $value;
 	}
 
@@ -543,46 +553,67 @@ function translate_section_label_prefix( string $value, array $labels ) : string
 }
 
 function render_transpose_controls_markup( array $labels ) : string {
-	return '<div class="chordpro-transpose-controls" role="group" aria-label="' . escape_html( $labels['transposeChords'] ) . '"><strong class="chordpro-meta-label">' . escape_html( $labels['transpose'] ) . ':</strong><button type="button" class="chordpro-transpose-button" data-transpose-change="-1" aria-label="' . escape_html( $labels['lowerSemitone'] ) . '">-</button><button type="button" class="chordpro-transpose-button" data-transpose-change="1" aria-label="' . escape_html( $labels['raiseSemitone'] ) . '">+</button><button type="button" class="chordpro-transpose-reset" data-transpose-reset disabled>' . escape_html( $labels['reset'] ) . '</button><span class="chordpro-transpose-value" data-transpose-display aria-live="polite" aria-atomic="true">0</span></div>';
+	$config  = get_spec()['render']['transposeControls'];
+	$buttons = '';
+
+	foreach ( $config['buttons'] as $button ) {
+		$attributes = array(
+			'type="button"',
+			'class="' . escape_html( $button['className'] ) . '"',
+			'aria-label="' . escape_html( $labels[ $button['labelKey'] ] ) . '"',
+		);
+
+		if ( 'change' === $button['kind'] ) {
+			$attributes[] = 'data-transpose-change="' . escape_html( $button['value'] ) . '"';
+		} elseif ( 'reset' === $button['kind'] ) {
+			$attributes[] = 'data-transpose-reset';
+		}
+
+		if ( ! empty( $button['disabled'] ) ) {
+			$attributes[] = 'disabled';
+		}
+
+		$label_text = isset( $button['textLabelKey'] ) ? $labels[ $button['textLabelKey'] ] : $button['text'];
+		$buttons   .= '<button ' . implode( ' ', $attributes ) . '>' . escape_html( $label_text ) . '</button>';
+	}
+
+	$display = $config['display'];
+
+	return '<div class="chordpro-transpose-controls" role="group" aria-label="' . escape_html( $labels[ $config['groupLabelKey'] ] ) . '"><strong class="chordpro-meta-label">' . escape_html( $labels[ $config['titleLabelKey'] ] ) . ':</strong>' . $buttons . '<span class="' . escape_html( $display['className'] ) . '" data-transpose-display aria-live="' . escape_html( $display['ariaLive'] ) . '" aria-atomic="' . escape_html( $display['ariaAtomic'] ) . '">' . escape_html( $display['initialValue'] ) . '</span></div>';
 }
 
 function render_directive_node( array $node, array $options, array $labels ) : string {
-	switch ( $node['key'] ) {
-		case 'title':
-		case 't':
-			if ( empty( $options['showTitle'] ) ) {
-				return '';
-			}
-			return '<div class="chordpro-title">' . escape_html( $node['value'] ) . '</div>';
-		case 'subtitle':
-		case 'st':
-			return '<div class="chordpro-subtitle">' . escape_html( $node['value'] ) . '</div>';
-		case 'artist':
-			if ( empty( $options['showArtist'] ) ) {
-				return '';
-			}
-			return '<div class="chordpro-artist">' . escape_html( $node['value'] ) . '</div>';
-		case 'composer':
-			return '<div class="chordpro-composer">' . escape_html( $node['value'] ) . '</div>';
-		case 'lyricist':
-			return '<div class="chordpro-lyricist">' . escape_html( $node['value'] ) . '</div>';
-		case 'key':
-			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">' . escape_html( $labels['keyLabel'] ) . ':</strong><span class="chordpro-meta-value" data-original-key="' . escape_html( $node['value'] ) . '">' . escape_html( $node['value'] ) . '</span></div>';
-		case 'capo':
-			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">' . escape_html( $labels['capoLabel'] ) . ':</strong><span class="chordpro-meta-value">' . escape_html( $node['value'] ) . '</span></div>';
-		case 'tempo':
-			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">' . escape_html( $labels['tempo'] ) . ':</strong><span class="chordpro-meta-value">' . escape_html( $node['value'] ) . '</span></div>';
-		case 'time':
-			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">' . escape_html( $labels['time'] ) . ':</strong><span class="chordpro-meta-value">' . escape_html( $node['value'] ) . '</span></div>';
-		case 'duration':
-			return '<div class="chordpro-meta"><strong class="chordpro-meta-label">' . escape_html( $labels['duration'] ) . ':</strong><span class="chordpro-meta-value">' . escape_html( $node['value'] ) . '</span></div>';
-		default:
-			return '';
+	$config = get_directive_render_config( $node['key'] );
+
+	if ( null === $config ) {
+		return '';
 	}
+
+	if ( ! empty( $config['option'] ) && empty( $options[ $config['option'] ] ) ) {
+		return '';
+	}
+
+	if ( 'text' === $config['kind'] ) {
+		return '<div class="' . escape_html( $config['className'] ) . '">' . escape_html( $node['value'] ) . '</div>';
+	}
+
+	if ( 'meta' === $config['kind'] ) {
+		$data_attribute = '';
+
+		if ( ! empty( $config['dataAttribute'] ) ) {
+			$data_attribute = ' ' . $config['dataAttribute'] . '="' . escape_html( $node['value'] ) . '"';
+		}
+
+		return '<div class="chordpro-meta"><strong class="chordpro-meta-label">' . escape_html( $labels[ $config['labelKey'] ] ) . ':</strong><span class="chordpro-meta-value"' . $data_attribute . '>' . escape_html( $node['value'] ) . '</span></div>';
+	}
+
+	return '';
 }
 
 function render_top_matter_node( array $node, array &$state, array $options, array $labels ) : string {
-	$items = $node['items'];
+	$node_types = get_node_types();
+	$items      = $node['items'];
+
 	usort(
 		$items,
 		static function ( array $first, array $second ) : int {
@@ -594,13 +625,13 @@ function render_top_matter_node( array $node, array &$state, array $options, arr
 		}
 	);
 
-	$html          = '';
+	$html           = '';
 	$meta_row_items = array();
 
 	foreach ( $items as $item ) {
 		$rendered = render_directive_node(
 			array(
-				'type'  => 'directive',
+				'type'  => $node_types['directive'],
 				'key'   => $item['key'],
 				'value' => $item['value'],
 			),
@@ -653,30 +684,31 @@ function render_chord_line_node( array $node ) : string {
 }
 
 function render_chordpro_document( array $document, array $options = array() ) : string {
-	$render_options = array(
+	$node_types      = get_node_types();
+	$render_options  = array(
 		'showTitle'       => array_key_exists( 'showTitle', $options ) ? (bool) $options['showTitle'] : true,
 		'showArtist'      => array_key_exists( 'showArtist', $options ) ? (bool) $options['showArtist'] : true,
 		'includeControls' => array_key_exists( 'includeControls', $options ) ? (bool) $options['includeControls'] : (bool) $document['features']['hasTransposableChords'],
 	);
-	$labels = get_labels( $options['labels'] ?? array() );
-	$state  = array(
+	$labels          = get_labels( $options['labels'] ?? array() );
+	$state           = array(
 		'controlsRendered' => false,
 		'openSections'     => 0,
 	);
-	$html = '';
+	$html            = '';
 
 	foreach ( $document['nodes'] as $node ) {
 		switch ( $node['type'] ) {
-			case 'top_matter':
+			case $node_types['topMatter']:
 				$html .= render_top_matter_node( $node, $state, $render_options, $labels );
 				break;
-			case 'directive':
+			case $node_types['directive']:
 				$html .= render_directive_node( $node, $render_options, $labels );
 				break;
-			case 'comment':
+			case $node_types['comment']:
 				$html .= render_comment_node( $node, $labels );
 				break;
-			case 'section_start':
+			case $node_types['sectionStart']:
 				$section_label = '';
 
 				if ( '' !== $node['label'] ) {
@@ -686,22 +718,22 @@ function render_chordpro_document( array $document, array $options = array() ) :
 				$html .= '<div class="chordpro-section chordpro-' . escape_html( $node['sectionType'] ) . '">' . $section_label;
 				++$state['openSections'];
 				break;
-			case 'section_end':
+			case $node_types['sectionEnd']:
 				if ( $state['openSections'] > 0 ) {
 					$html .= '</div>';
 					--$state['openSections'];
 				}
 				break;
-			case 'tab_block':
+			case $node_types['tabBlock']:
 				$html .= '<pre class="chordpro-tab">' . escape_html( implode( "\n", $node['lines'] ) ) . '</pre>';
 				break;
-			case 'spacer':
+			case $node_types['spacer']:
 				$html .= '<div class="chordpro-spacer"></div>';
 				break;
-			case 'lyric_line':
+			case $node_types['lyricLine']:
 				$html .= '<div class="chordpro-line"><p class="chordpro-lyric chordpro-lyric-plain">' . escape_html( $node['text'] ) . '</p></div>';
 				break;
-			case 'chord_line':
+			case $node_types['chordLine']:
 				$html .= render_chord_line_node( $node );
 				break;
 		}

--- a/src/render.php
+++ b/src/render.php
@@ -63,23 +63,13 @@ if ( 'roboto' === $font_family ) {
 	$font_class = 'chordpro-font-martian';
 }
 
-$labels = array(
-	'verse'             => __( 'Verse', 'chordpro-block' ),
-	'chorus'            => __( 'Chorus', 'chordpro-block' ),
-	'bridge'            => __( 'Bridge', 'chordpro-block' ),
-	'keyLabel'          => _x( 'Key', 'musical key label', 'chordpro-block' ),
-	'capoLabel'         => _x( 'Capo', 'guitar capo position', 'chordpro-block' ),
-	'tempo'             => __( 'Tempo', 'chordpro-block' ),
-	'time'              => __( 'Time', 'chordpro-block' ),
-	'duration'          => __( 'Duration', 'chordpro-block' ),
-	'transpose'         => __( 'Transpose', 'chordpro-block' ),
-	'transposeChords'   => __( 'Transpose chords', 'chordpro-block' ),
-	'lowerSemitone'     => __( 'Lower one semitone', 'chordpro-block' ),
-	'raiseSemitone'     => __( 'Raise one semitone', 'chordpro-block' ),
-	'reset'             => __( 'Reset', 'chordpro-block' ),
-	'transposeOffset'   => __( 'Transpose offset 0 semitones', 'chordpro-block' ),
-	'songLyricsDefault' => __( 'Song Lyrics', 'chordpro-block' ),
-);
+$labels = array();
+
+foreach ( \ChordProBlock\Parser\get_label_definitions() as $key => $definition ) {
+	$labels[ $key ] = '_x' === ( $definition['function'] ?? '__' )
+		? _x( $definition['text'], $definition['context'] ?? '', 'chordpro-block' )
+		: __( $definition['text'], 'chordpro-block' );
+}
 
 $document     = \ChordProBlock\Parser\parse_chordpro_document( $raw_content );
 $song_html    = \ChordProBlock\Parser\render_chordpro_document(

--- a/tests/fixtures/parser-cases.json
+++ b/tests/fixtures/parser-cases.json
@@ -14,14 +14,7 @@
 				"hasTransposableChords": true
 			},
 			"nodeTypes": [ "top_matter", "chord_line" ],
-			"htmlIncludes": [
-				"class=\"chordpro-title\"",
-				"class=\"chordpro-meta-bar\"",
-				"data-original-key=\"F\"",
-				"data-transpose-change=\"1\"",
-				"class=\"chordpro-accessible-line\""
-			],
-			"htmlExcludes": []
+			"html": "<div class=\"chordpro-title\">Amazing Grace</div><div class=\"chordpro-artist\">John Newton</div><div class=\"chordpro-meta-bar\"><div class=\"chordpro-meta\"><strong class=\"chordpro-meta-label\">Tempo:</strong><span class=\"chordpro-meta-value\">72</span></div><div class=\"chordpro-meta\"><strong class=\"chordpro-meta-label\">Key:</strong><span class=\"chordpro-meta-value\" data-original-key=\"F\">F</span></div></div><div class=\"chordpro-transpose-row\"><div class=\"chordpro-transpose-controls\" role=\"group\" aria-label=\"Transpose chords\"><strong class=\"chordpro-meta-label\">Transpose:</strong><button type=\"button\" class=\"chordpro-transpose-button\" data-transpose-change=\"-1\" aria-label=\"Lower one semitone\">-</button><button type=\"button\" class=\"chordpro-transpose-button\" data-transpose-change=\"1\" aria-label=\"Raise one semitone\">+</button><button type=\"button\" class=\"chordpro-transpose-reset\" data-transpose-reset disabled aria-label=\"Reset\">Reset</button><span class=\"chordpro-transpose-value\" data-transpose-display aria-live=\"polite\" aria-atomic=\"true\">0</span></div></div><div class=\"chordpro-line chordpro-line-annotated\"><span class=\"chordpro-accessible-line\">C Amazing F grace</span><div class=\"chordpro-chords\" aria-hidden=\"true\"><p class=\"chordpro-chord\" data-original-chord=\"C\" data-lyric-position=\"0\" data-lyric-segment-length=\"8\" style=\"left:0ch\">C</p><p class=\"chordpro-chord\" data-original-chord=\"F\" data-lyric-position=\"8\" data-lyric-segment-length=\"5\" style=\"left:8ch\">F</p></div><p class=\"chordpro-lyric chordpro-lyric-full\" aria-hidden=\"true\">Amazing grace</p></div>"
 		}
 	},
 	{
@@ -37,11 +30,7 @@
 				"hasTransposableChords": false
 			},
 			"nodeTypes": [ "top_matter", "chord_line" ],
-			"htmlIncludes": [
-				"class=\"chordpro-accessible-line\"",
-				"data-original-chord=\"N.C.\""
-			],
-			"htmlExcludes": [ "data-transpose-change" ]
+			"html": "<div class=\"chordpro-title\">Spoken Word</div><div class=\"chordpro-line chordpro-line-annotated\"><span class=\"chordpro-accessible-line\">N.C. Hello</span><div class=\"chordpro-chords\" aria-hidden=\"true\"><p class=\"chordpro-chord\" data-original-chord=\"N.C.\" data-lyric-position=\"0\" data-lyric-segment-length=\"5\" style=\"left:0ch\">N.C.</p></div><p class=\"chordpro-lyric chordpro-lyric-full\" aria-hidden=\"true\">Hello</p></div>"
 		}
 	},
 	{
@@ -64,12 +53,7 @@
 				"tab_block",
 				"lyric_line"
 			],
-			"htmlIncludes": [
-				"class=\"chordpro-section chordpro-chorus\"",
-				"class=\"chordpro-tab\"",
-				"Plain line"
-			],
-			"htmlExcludes": []
+			"html": "<div class=\"chordpro-transpose-controls\" role=\"group\" aria-label=\"Transpose chords\"><strong class=\"chordpro-meta-label\">Transpose:</strong><button type=\"button\" class=\"chordpro-transpose-button\" data-transpose-change=\"-1\" aria-label=\"Lower one semitone\">-</button><button type=\"button\" class=\"chordpro-transpose-button\" data-transpose-change=\"1\" aria-label=\"Raise one semitone\">+</button><button type=\"button\" class=\"chordpro-transpose-reset\" data-transpose-reset disabled aria-label=\"Reset\">Reset</button><span class=\"chordpro-transpose-value\" data-transpose-display aria-live=\"polite\" aria-atomic=\"true\">0</span></div><div class=\"chordpro-subtitle\">Live</div><div class=\"chordpro-section chordpro-chorus\"><div class=\"chordpro-section-label\">Chorus</div><div class=\"chordpro-line chordpro-line-annotated\"><span class=\"chordpro-accessible-line\">C Sing</span><div class=\"chordpro-chords\" aria-hidden=\"true\"><p class=\"chordpro-chord\" data-original-chord=\"C\" data-lyric-position=\"0\" data-lyric-segment-length=\"4\" style=\"left:0ch\">C</p></div><p class=\"chordpro-lyric chordpro-lyric-full\" aria-hidden=\"true\">Sing</p></div></div><pre class=\"chordpro-tab\">E|---0---|</pre><div class=\"chordpro-line\"><p class=\"chordpro-lyric chordpro-lyric-plain\">Plain line</p></div>"
 		}
 	}
 ]

--- a/tests/unit/chordpro-document.test.js
+++ b/tests/unit/chordpro-document.test.js
@@ -36,12 +36,6 @@ describe( 'ChordPro document fixtures', () => {
 			fixture.expected.nodeTypes
 		);
 
-		fixture.expected.htmlIncludes.forEach( ( fragment ) => {
-			expect( html ).toContain( fragment );
-		} );
-
-		fixture.expected.htmlExcludes.forEach( ( fragment ) => {
-			expect( html ).not.toContain( fragment );
-		} );
+		expect( html ).toBe( fixture.expected.html );
 	} );
 } );


### PR DESCRIPTION
## Summary
- Centralize ChordPro grammar, node types, labels, and control config in a shared spec
- Generate JS labels and PHP spec wrappers from that contract to avoid manual drift
- Tighten parity checks to compare full rendered HTML snapshots
- Update fixtures and tests to cover the shared parser/render output

## Testing
- `npm run test:unit`
- `npm run build`
- `npm run test:parity` (skipped PHP execution in this environment because `php` is unavailable)