### PR TITLE
Fix literal bracket handling in ChordPro parsing

### DIFF
--- a/src/chordpro-document.js
+++ b/src/chordpro-document.js
@@ -4,7 +4,9 @@ import { isTransposableChord } from './chordpro-transpose';
 const STRUCTURAL_DIRECTIVE_RE =
 	/^[{\[]\s*((?:start_of_|end_of_)(?:verse|chorus|bridge|tab)|sov|eov|soc|eoc|sob|eob|sot|eot)(?:\s*:\s*[^}\]]*)?\s*[}\]]$/i;
 const DIRECTIVE_LINE_RE = /^\{([^}]+)\}$/;
-const CHORD_TOKEN_RE = /\[[^\]]+\]/;
+const ESCAPED_BRACKET_RE = /\\([\[\]])/g;
+const VALID_CHORD_TOKEN_RE =
+	/^(?:N\.?C\.?|[A-G](?:b|#)?(?:maj|min|mi|m|dim|aug|sus|add|omit|no|dom|M|Δ|ø|o|\+|-|[0-9]+|[#b][0-9]+|\([^\s)]+\)|\/[A-G](?:b|#)?)*)$/;
 
 const TOP_MATTER_KEYS = [
 	'title',
@@ -106,8 +108,129 @@ function getTopMatterPriority( key ) {
 	}
 }
 
+function unescapeBracketLiterals( text ) {
+	return text.replace( ESCAPED_BRACKET_RE, '$1' );
+}
+
+function isValidChordToken( token ) {
+	const trimmed = token.trim();
+
+	return !! trimmed && VALID_CHORD_TOKEN_RE.test( trimmed );
+}
+
+function isEscapedCharacter( value, index ) {
+	let slashCount = 0;
+
+	for (
+		let cursor = index - 1;
+		cursor >= 0 && value[ cursor ] === '\\';
+		cursor--
+	) {
+		slashCount++;
+	}
+
+	return slashCount % 2 === 1;
+}
+
+function findClosingBracket( line, startIndex ) {
+	for ( let cursor = startIndex + 1; cursor < line.length; cursor++ ) {
+		if ( line[ cursor ] === ']' && ! isEscapedCharacter( line, cursor ) ) {
+			return cursor;
+		}
+	}
+
+	return -1;
+}
+
+function tokenizeChordLine( line ) {
+	const tokens = [];
+	const entries = [];
+	let buffer = '';
+	let activeEntry = null;
+	let leadingText = '';
+
+	for ( let index = 0; index < line.length; index++ ) {
+		const current = line[ index ];
+		const next = line[ index + 1 ];
+
+		if ( current === '\\' && [ '[', ']' ].includes( next ) ) {
+			buffer += next;
+			index++;
+			continue;
+		}
+
+		if ( current !== '[' ) {
+			buffer += current;
+			continue;
+		}
+
+		const closingBracket = findClosingBracket( line, index );
+
+		if ( closingBracket === -1 ) {
+			buffer += current;
+			continue;
+		}
+
+		const tokenContent = line.substring( index + 1, closingBracket );
+
+		if ( isValidChordToken( tokenContent ) ) {
+			if ( buffer ) {
+				tokens.push( {
+					type: 'text',
+					value: buffer,
+				} );
+				buffer = '';
+			}
+
+			tokens.push( {
+				type: 'chord',
+				value: tokenContent.trim(),
+			} );
+			index = closingBracket;
+			continue;
+		}
+
+		buffer += `[${ unescapeBracketLiterals( tokenContent ) }]`;
+		index = closingBracket;
+	}
+
+	if ( buffer ) {
+		tokens.push( {
+			type: 'text',
+			value: buffer,
+		} );
+	}
+
+	tokens.forEach( ( token ) => {
+		if ( token.type === 'chord' ) {
+			activeEntry = {
+				chord: token.value,
+				lyric: '',
+			};
+			entries.push( activeEntry );
+			return;
+		}
+
+		if ( activeEntry ) {
+			activeEntry.lyric += token.value;
+			return;
+		}
+
+		leadingText += token.value;
+	} );
+
+	if ( entries.length === 0 ) {
+		return null;
+	}
+
+	return {
+		leadingText,
+		entries,
+	};
+}
+
 function hasChordTokens( line ) {
-	return CHORD_TOKEN_RE.test( line );
+	return !! tokenizeChordLine( line );
 }
 
 function buildAccessibleChordLine( leadingText, segments ) {
@@ -133,26 +256,27 @@ function buildAccessibleChordLine( leadingText, segments ) {
 }
 
 function parseChordLine( line ) {
+	const parsedLine = tokenizeChordLine( line );
+
+	if ( ! parsedLine ) {
+		return null;
+	}
+
 	let lyricText = '';
 	const markers = [];
-	const firstBracket = line.indexOf( '[' );
 	let lyricPosition = 0;
 	let chordOffset = 0;
-	let leadingText = '';
+	const leadingText = parsedLine.leadingText;
 	const segments = [];
 
-	if ( firstBracket > 0 ) {
-		leadingText = line.substring( 0, firstBracket );
+	if ( leadingText ) {
 		lyricText += leadingText;
 		lyricPosition += Array.from( leadingText ).length;
 	}
 
-	const pattern = /\[([^\]]*)\]([^[]*)/g;
-	let match;
-
-	while ( ( match = pattern.exec( line ) ) !== null ) {
-		const chord = match[ 1 ];
-		const lyric = match[ 2 ];
+	parsedLine.entries.forEach( ( entry ) => {
+		const chord = entry.chord;
+		const lyric = entry.lyric;
 		const segmentLength = Array.from( lyric ).length;
 		const chordLength = Array.from( chord ).length;
 		const baseLyricPosition = lyricPosition;
@@ -173,7 +297,7 @@ function parseChordLine( line ) {
 		} else {
 			chordOffset += chordLength + 1;
 		}
-	}
+	} );
 
 	return {
 		type: 'chord_line',
@@ -480,6 +604,15 @@ export function createChordProDocument( text ) {
 
 			const chordLine = parseChordLine( line );
 
+			if ( ! chordLine ) {
+				document.nodes.push( {
+					type: 'lyric_line',
+					text: unescapeBracketLiterals( line ),
+				} );
+				lyricsLines.push( unescapeBracketLiterals( line ) );
+				continue;
+			}
+
 			document.features.hasChords = true;
 			document.features.hasTransposableChords =
 				document.features.hasTransposableChords ||
@@ -489,12 +622,14 @@ export function createChordProDocument( text ) {
 			continue;
 		}
 
+		const plainLine = unescapeBracketLiterals( line );
+
 		flushTopMatter( parserState );
 		document.nodes.push( {
 			type: 'lyric_line',
-			text: line,
+			text: plainLine,
 		} );
-		lyricsLines.push( line );
+		lyricsLines.push( plainLine );
 	}
 
 	flushTopMatter( parserState );

--- a/src/edit.js
+++ b/src/edit.js
@@ -56,7 +56,7 @@ export default function Edit( { attributes, setAttributes } ) {
 				className="chordpro-editor__textarea"
 				label={ __( 'ChordPro content', 'chordpro-block' ) }
 				help={ __(
-					'Write your song using ChordPro notation. Place chords inline with [Chord] and use {directive: value} for metadata and section markers.',
+					'Write your song using ChordPro notation. Place chords inline with [Chord], use {directive: value} for metadata and section markers, and escape literal brackets as \\[text\\].',
 					'chordpro-block'
 				) }
 				value={ content }

--- a/src/parser.php
+++ b/src/parser.php
@@ -164,8 +164,128 @@ function get_top_matter_priority( string $key ) : int {
 	}
 }
 
+function unescape_bracket_literals( string $value ) : string {
+	return preg_replace( '/\\\\([\[\]])/u', '$1', $value ) ?? $value;
+}
+
+function is_valid_chord_token( string $token ) : bool {
+	$trimmed = trim( $token );
+
+	return '' !== $trimmed && 1 === preg_match( '/^(?:N\.?C\.?|[A-G](?:b|#)?(?:maj|min|mi|m|dim|aug|sus|add|omit|no|dom|M|Δ|ø|o|\+|-|[0-9]+|[#b][0-9]+|\([^\s)]+\)|\/[A-G](?:b|#)?)*)$/u', $trimmed );
+}
+
+function is_escaped_character( string $value, int $index ) : bool {
+	$slash_count = 0;
+
+	for ( $cursor = $index - 1; $cursor >= 0 && '\\' === $value[ $cursor ]; $cursor-- ) {
+		++$slash_count;
+	}
+
+	return 1 === $slash_count % 2;
+}
+
+function find_closing_bracket( string $line, int $start_index ) : int {
+	for ( $cursor = $start_index + 1, $length = strlen( $line ); $cursor < $length; $cursor++ ) {
+		if ( ']' === $line[ $cursor ] && ! is_escaped_character( $line, $cursor ) ) {
+			return $cursor;
+		}
+	}
+
+	return -1;
+}
+
+function tokenize_chord_line( string $line ) : ?array {
+	$tokens        = array();
+	$entries       = array();
+	$buffer        = '';
+	$leading_text  = '';
+	$active_entry  = null;
+	$seen_chord    = false;
+	$length        = strlen( $line );
+
+	for ( $index = 0; $index < $length; $index++ ) {
+		$current = $line[ $index ];
+		$next    = $index + 1 < $length ? $line[ $index + 1 ] : null;
+
+		if ( '\\' === $current && in_array( $next, array( '[', ']' ), true ) ) {
+			$buffer .= $next;
+			++$index;
+			continue;
+		}
+
+		if ( '[' !== $current ) {
+			$buffer .= $current;
+			continue;
+		}
+
+		$closing_bracket = find_closing_bracket( $line, $index );
+
+		if ( -1 === $closing_bracket ) {
+			$buffer .= $current;
+			continue;
+		}
+
+		$token_content = substr( $line, $index + 1, $closing_bracket - $index - 1 );
+
+		if ( is_valid_chord_token( $token_content ) ) {
+			if ( '' !== $buffer ) {
+				$tokens[] = array(
+					'type'  => 'text',
+					'value' => $buffer,
+				);
+				$buffer = '';
+			}
+
+			$tokens[] = array(
+				'type'  => 'chord',
+				'value' => trim( $token_content ),
+			);
+			$index = $closing_bracket;
+			continue;
+		}
+
+		$buffer .= '[' . unescape_bracket_literals( $token_content ) . ']';
+		$index   = $closing_bracket;
+	}
+
+	if ( '' !== $buffer ) {
+		$tokens[] = array(
+			'type'  => 'text',
+			'value' => $buffer,
+		);
+	}
+
+	foreach ( $tokens as $token ) {
+		if ( 'chord' === $token['type'] ) {
+			$entries[] = array(
+				'chord' => $token['value'],
+				'lyric' => '',
+			);
+			$active_entry = count( $entries ) - 1;
+			$seen_chord   = true;
+			continue;
+		}
+
+		if ( $seen_chord && null !== $active_entry ) {
+			$entries[ $active_entry ]['lyric'] .= $token['value'];
+			continue;
+		}
+
+		$leading_text .= $token['value'];
+	}
+
+	if ( empty( $entries ) ) {
+		return null;
+	}
+
+	return array(
+		'leadingText' => $leading_text,
+		'entries'     => $entries,
+	);
+}
+
 function has_chord_tokens( string $line ) : bool {
-	return 1 === preg_match( '/\[[^\]]+\]/u', $line );
+	return null !== tokenize_chord_line( $line );
 }
 
 function normalize_whitespace( string $value ) : string {
@@ -197,26 +317,29 @@ function is_transposable_chord( string $chord ) : bool {
 	return '' !== $trimmed && ! preg_match( '/^(?:N\.?C\.?)$/i', $trimmed ) && 1 === preg_match( '/^([A-G](?:b|#)?)/', $trimmed );
 }
 
-function parse_chord_line( string $line ) : array {
+function parse_chord_line( string $line ) : ?array {
+	$parsed_line    = tokenize_chord_line( $line );
 	$lyric_text    = '';
 	$markers       = array();
 	$segments      = array();
-	$first_bracket = strpos( $line, '[' );
 	$lyric_position = 0;
 	$chord_offset   = 0;
 	$leading_text   = '';
 
-	if ( false !== $first_bracket && $first_bracket > 0 ) {
-		$leading_text    = substr( $line, 0, $first_bracket );
+	if ( null === $parsed_line ) {
+		return null;
+	}
+
+	$leading_text = $parsed_line['leadingText'];
+
+	if ( '' !== $leading_text ) {
 		$lyric_text     .= $leading_text;
 		$lyric_position += string_length( $leading_text );
 	}
 
-	preg_match_all( '/\[([^\]]*)\]([^\[]*)/u', $line, $matches, PREG_SET_ORDER );
-
-	foreach ( $matches as $match ) {
-		$chord            = $match[1];
-		$lyric            = $match[2];
+	foreach ( $parsed_line['entries'] as $entry ) {
+		$chord            = $entry['chord'];
+		$lyric            = $entry['lyric'];
 		$segment_length   = string_length( $lyric );
 		$chord_length     = string_length( $chord );
 		$base_position    = $lyric_position;
@@ -499,6 +622,17 @@ function parse_chordpro_document( string $text ) : array {
 			flush_top_matter( $document, $pending_top_matter, $top_matter_flushed );
 			$chord_line = parse_chord_line( $line );
 
+			if ( null === $chord_line ) {
+				$plain_line = unescape_bracket_literals( $line );
+
+				$document['nodes'][] = array(
+					'type' => 'lyric_line',
+					'text' => $plain_line,
+				);
+				$lyrics_lines[] = $plain_line;
+				continue;
+			}
+
 			$document['features']['hasChords'] = true;
 			$document['features']['hasTransposableChords'] = $document['features']['hasTransposableChords'] || $chord_line['hasTransposableChord'];
 			$document['nodes'][] = $chord_line;
@@ -507,11 +641,13 @@ function parse_chordpro_document( string $text ) : array {
 		}
 
 		flush_top_matter( $document, $pending_top_matter, $top_matter_flushed );
+		$plain_line = unescape_bracket_literals( $line );
+
 		$document['nodes'][] = array(
 			'type' => 'lyric_line',
-			'text' => $line,
+			'text' => $plain_line,
 		);
-		$lyrics_lines[] = $line;
+		$lyrics_lines[] = $plain_line;
 	}
 
 	flush_top_matter( $document, $pending_top_matter, $top_matter_flushed );

--- a/tests/fixtures/parser-cases.json
+++ b/tests/fixtures/parser-cases.json
@@ -71,5 +71,69 @@
 			],
 			"htmlExcludes": []
 		}
+	},
+	{
+		"name": "treats literal bracket text as plain lyrics",
+		"input": "Letra [spoken] aquí",
+		"expected": {
+			"meta": {
+				"lyrics": "Letra [spoken] aquí"
+			},
+			"features": {
+				"hasChords": false,
+				"hasTransposableChords": false
+			},
+			"nodeTypes": [ "lyric_line" ],
+			"htmlIncludes": [
+				"Letra [spoken] aquí"
+			],
+			"htmlExcludes": [
+				"data-original-chord",
+				"chordpro-line-annotated"
+			]
+		}
+	},
+	{
+		"name": "keeps invalid bracket tokens as lyrics inside chord lines",
+		"input": "[C]Letra [spoken] aquí [G]final",
+		"expected": {
+			"meta": {
+				"lyrics": "Letra [spoken] aquí final"
+			},
+			"features": {
+				"hasChords": true,
+				"hasTransposableChords": true
+			},
+			"nodeTypes": [ "chord_line" ],
+			"htmlIncludes": [
+				"data-original-chord=\"C\"",
+				"data-original-chord=\"G\"",
+				"[spoken]"
+			],
+			"htmlExcludes": [
+				"data-original-chord=\"spoken\""
+			]
+		}
+	},
+	{
+		"name": "supports escaped bracket literals",
+		"input": "\\[C\\] no es acorde",
+		"expected": {
+			"meta": {
+				"lyrics": "[C] no es acorde"
+			},
+			"features": {
+				"hasChords": false,
+				"hasTransposableChords": false
+			},
+			"nodeTypes": [ "lyric_line" ],
+			"htmlIncludes": [
+				"[C] no es acorde"
+			],
+			"htmlExcludes": [
+				"data-original-chord",
+				"chordpro-line-annotated"
+			]
+		}
 	}
 ]


### PR DESCRIPTION
## Summary
- Treat only valid ChordPro tokens as chords, so literal bracketed text stays in lyrics
- Support escaped brackets with `\[` and `\]`
- Update JS and PHP parsers in sync and add shared regression fixtures

## Testing
- `npm run lint:js`
- `npm run test:unit`
- `npm run build`